### PR TITLE
Add Bitwarden server region support

### DIFF
--- a/BitwardenModel.js
+++ b/BitwardenModel.js
@@ -740,6 +740,19 @@ function authPasswordWriteCommand(channel) {
 // means the official server), or the reason it was refused.
 var SERVER_SCHEME_RE = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//
 var LOOPBACK_HOST_RE = /^(?:localhost|127(?:\.\d{1,3}){3}|\[::1\]|::1)$/i
+var BITWARDEN_US_SERVER = "https://vault.bitwarden.com"
+var BITWARDEN_EU_SERVER = "https://vault.bitwarden.eu"
+
+// Both cloud regions are explicit because bw persists its last configured
+// server. An empty US override after an EU login would keep sending the next
+// login to EU. Unknown UI state fails closed to US instead of accidentally
+// sending credentials to a stale custom URL.
+function loginServerUrlFor(region, customUrl) {
+  var choice = String(region || "").toLowerCase()
+  if (choice === "eu") return BITWARDEN_EU_SERVER
+  if (choice === "custom") return String(customUrl || "").trim()
+  return BITWARDEN_US_SERVER
+}
 
 function validateServerUrl(raw) {
   var url = String(raw || "").trim()
@@ -816,8 +829,11 @@ var HANDOFF_BASENAME = "session-handoff"
 // `mode` is "login" when logged out and "unlock" when merely locked. The panel
 // already knows which, so this does not probe with `bw status` first -- that
 // probe measured at ~3.3s, spent before the user was even shown a prompt.
-function terminalLoginCommand(mode) {
+function terminalLoginCommand(mode, serverUrl) {
   var verb = (mode === "unlock") ? "unlock" : "login"
+  var configureServer = (verb === "login" && serverUrl && serverUrl.trim())
+    ? "bw config server " + shellQuote(serverUrl.trim()) + " >/dev/null 2>&1 && "
+    : ""
   var inner = "set -u; "
     + "d=\"${XDG_RUNTIME_DIR:?no XDG_RUNTIME_DIR -- refusing to write a session key}/"
     + RUNTIME_SUBDIR + "\"; f=\"$d/" + HANDOFF_BASENAME + "\"; "
@@ -831,6 +847,7 @@ function terminalLoginCommand(mode) {
     // Remove a stale entry before opening the output path, so a pre-created
     // symlink is unlinked rather than followed by shell redirection.
     + "rm -f -- \"$f\" || exit 1; "
+    + configureServer
     + "if bw " + verb + " --raw > \"$f\" && [ -s \"$f\" ]; then "
     // Bring the panel back itself rather than making the user find it again.
     // Only the method name crosses this boundary; the key never does.

--- a/Panel.qml
+++ b/Panel.qml
@@ -71,11 +71,11 @@ Panel {
   property string loginEmail: ""
   property string loginPassword: ""
   property string login2faCode: ""
+  property string loginServerRegion: "us" // "us" | "eu" | "custom"
   property string loginServerUrl: ""
   property string loginClientId: ""
   property string loginClientSecret: ""
   property bool show2faField: false
-  property bool showServerField: false
   // Whether the login attempt now running carries --code. It is the only way
   // to tell a rejected two-step code from a new-device-verification challenge;
   // see loginNeedsDeviceVerification() in BitwardenModel.js.
@@ -1561,9 +1561,21 @@ Panel {
 
   function emailLoginSignature() {
     return String(loginEmail || "").trim() + "\n"
-      + String(loginServerUrl || "").trim() + "\n"
+      + resolvedLoginServerUrl() + "\n"
       + (String(login2faCode || "").trim() ? "2fa" : "plain") + "\n"
       + String(login2faMethod)
+  }
+
+  function resolvedLoginServerUrl() {
+    return Model.loginServerUrlFor(loginServerRegion, loginServerUrl)
+  }
+
+  function selectLoginServerRegion(region) {
+    if (loginServerRegion === region) return
+    loginServerRegion = region
+    errorMessage = ""
+    resetEmailLoginSecondFactor()
+    invalidateEmailLoginPrewarm()
   }
 
   function invalidateEmailLoginPrewarm() {
@@ -1645,7 +1657,7 @@ Panel {
     // the exit handler read it.
     deviceVerificationAttempt = true
     loginProc.command = Model.deviceVerificationLoginCommand(
-      String(loginEmail || "").trim(), String(loginServerUrl || "").trim(), login2faMethod)
+      String(loginEmail || "").trim(), resolvedLoginServerUrl(), login2faMethod)
     loginProc.running = true
     loginSubmitted = true
     writeAuthPassword("login", loginPassword)
@@ -1731,11 +1743,12 @@ Panel {
   function prepareEmailLogin() {
     if (logoutPending || !opened || status !== "unauthenticated" || loginMethod !== "email" || isLoading) return
     var email = String(loginEmail || "").trim()
-    if (!email || Model.validateServerUrl(loginServerUrl)) return
+    var serverUrl = resolvedLoginServerUrl()
+    if (!email || Model.validateServerUrl(serverUrl)) return
     // Configuring a custom server changes bw's persistent global state. Do it
     // only after explicit submission, never merely because the password field
     // received focus. Default-cloud logins still get the full prewarm win.
-    if (String(loginServerUrl || "").trim()) return
+    if (serverUrl) return
 
     var signature = emailLoginSignature()
     if (loginProc.running) {
@@ -1752,7 +1765,7 @@ Panel {
     loginAttemptHadCode = String(login2faCode || "").trim().length > 0
     loginAttemptMethod = login2faMethod
     loginProc.command = Model.emailLoginPrewarmCommand(
-      email, loginAttemptHadCode, String(loginServerUrl || "").trim(), login2faMethod)
+      email, loginAttemptHadCode, serverUrl, login2faMethod)
     loginProc.running = true
   }
 
@@ -1857,10 +1870,10 @@ Panel {
 
     // Checked before either branch, because both send the master password to
     // whatever this names. See validateServerUrl() for what it refuses.
-    var serverProblem = Model.validateServerUrl(loginServerUrl)
+    var serverUrl = resolvedLoginServerUrl()
+    var serverProblem = Model.validateServerUrl(serverUrl)
     if (serverProblem) {
       errorMessage = serverProblem
-      showServerField = true
       return
     }
 
@@ -1899,7 +1912,7 @@ Panel {
         loginAttemptHadCode = login2faCode.trim().length > 0
         loginAttemptMethod = login2faMethod
         loginProc.command = Model.emailLoginPrewarmCommand(
-          email, loginAttemptHadCode, loginServerUrl.trim(), login2faMethod)
+          email, loginAttemptHadCode, serverUrl, login2faMethod)
         loginProc.running = true
       }
       loginSubmitted = true
@@ -1934,7 +1947,7 @@ Panel {
       loginPrewarmSignature = ""
       loginAttemptHadCode = false
       loginAttemptMethod = -1
-      loginProc.command = Model.apiKeyLoginCommand(loginServerUrl.trim())
+      loginProc.command = Model.apiKeyLoginCommand(serverUrl)
       loginProc.running = true
     }
   }
@@ -2106,11 +2119,17 @@ Panel {
     // The panel knows whether this is a login or an unlock, so the terminal
     // does not have to spend a `bw status` round trip working it out.
     var mode = (status === "locked") ? "unlock" : "login"
+    var serverUrl = mode === "login" ? resolvedLoginServerUrl() : ""
+    var serverProblem = Model.validateServerUrl(serverUrl)
+    if (serverProblem) {
+      errorMessage = serverProblem
+      return
+    }
     close()
     // Opens the window in which a handed-over session key is accepted. See
     // refreshStatus().
     terminalLoginStartedAt = Date.now()
-    Quickshell.execDetached(Model.terminalLoginCommand(mode))
+    Quickshell.execDetached(Model.terminalLoginCommand(mode, serverUrl))
   }
 
   function logoutAccount() {
@@ -8048,6 +8067,64 @@ Panel {
             }
           }
 
+          Column {
+            visible: root.loginMethod !== "email" || root.loginCredentialsStage
+            width: parent.width
+            spacing: Style.space(5)
+
+            Text {
+              textFormat: Text.PlainText
+              text: "SERVER REGION"
+              color: root.dim
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              font.bold: true
+            }
+
+            Row {
+              anchors.horizontalCenter: parent.horizontalCenter
+              spacing: Style.space(6)
+
+              Button {
+                text: "US"
+                selected: root.loginServerRegion === "us"
+                fontFamily: root.fontFamily
+                fontSize: Style.font.caption
+                onClicked: root.selectLoginServerRegion("us")
+              }
+
+              Button {
+                text: "EU"
+                selected: root.loginServerRegion === "eu"
+                fontFamily: root.fontFamily
+                fontSize: Style.font.caption
+                onClicked: root.selectLoginServerRegion("eu")
+              }
+
+              Button {
+                text: "Custom"
+                selected: root.loginServerRegion === "custom"
+                fontFamily: root.fontFamily
+                fontSize: Style.font.caption
+                onClicked: root.selectLoginServerRegion("custom")
+              }
+            }
+
+            TextField {
+              id: serverUrlField
+              visible: root.loginServerRegion === "custom"
+              width: parent.width
+              placeholderText: "https://vault.example.com"
+              text: root.loginServerUrl
+              onTextChanged: root.loginServerUrl = text
+              onTextEdited: {
+                root.loginServerUrl = text
+                root.resetEmailLoginSecondFactor()
+                root.invalidateEmailLoginPrewarm()
+              }
+            }
+          }
+
           // METHOD A: Email & Password
           Column {
             visible: root.loginMethod === "email"
@@ -8320,44 +8397,6 @@ Panel {
                     root.invalidateEmailLoginPrewarm()
                     root.reopenTwoFactorMethodPicker()
                   }
-                }
-              }
-            }
-
-            // Custom Server URL (collapsible)
-            Column {
-              visible: root.loginCredentialsStage
-              width: parent.width
-              spacing: Style.space(4)
-
-              MouseArea {
-                width: parent.width
-                height: Style.space(20)
-                cursorShape: Qt.PointingHandCursor
-                onClicked: root.showServerField = !root.showServerField
-                Row {
-                  spacing: Style.space(4)
-                  Text {
-                    textFormat: Text.PlainText
-                    text: root.showServerField ? "▾ Custom Server URL" : "▸ Custom Server (Self-hosted Vaultwarden)"
-                    color: root.dim
-                    font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
-                  }
-                }
-              }
-
-              TextField {
-                id: serverUrlField
-                visible: root.showServerField
-                width: parent.width
-                placeholderText: "https://vault.example.com"
-                text: root.loginServerUrl
-                onTextChanged: root.loginServerUrl = text
-                onTextEdited: {
-                  root.loginServerUrl = text
-                  root.resetEmailLoginSecondFactor()
-                  root.invalidateEmailLoginPrewarm()
                 }
               }
             }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ You can reopen it any time with <kbd>,</kbd> from the settings screen, or:
 omarchy-shell io.github.elevate08.qs-bitwarden-cli setup
 ```
 
+On the login screen, choose **US** (the default), **EU**, or **Custom** under
+**Server Region**. EU connects the Bitwarden CLI to
+`https://vault.bitwarden.eu`; Custom reveals the existing server URL field for
+self-hosted Bitwarden and Vaultwarden installations. The selection applies to
+email/password, API-key, and interactive terminal login.
+
 <details>
 <summary>What the setup screen installs, and why</summary>
 

--- a/tests/auth-prewarm.test.js
+++ b/tests/auth-prewarm.test.js
@@ -284,8 +284,9 @@ check("focusing the email-login password field prepares login",
   "loginPassField has no prewarm focus handler")
 const prepareEmail = bodyOf("prepareEmailLogin")
 check("a custom server is not configured by focus-only prewarming",
-  /String\(loginServerUrl\s*\|\|\s*""\)\.trim\(\)[\s\S]{0,80}return/.test(prepareEmail)
-    && prepareEmail.indexOf("String(loginServerUrl") < prepareEmail.indexOf("loginProc.command"),
+  /var serverUrl\s*=\s*resolvedLoginServerUrl\(\)/.test(prepareEmail)
+    && /if\s*\(serverUrl\)\s*return/.test(prepareEmail)
+    && prepareEmail.indexOf("resolvedLoginServerUrl") < prepareEmail.indexOf("loginProc.command"),
   prepareEmail)
 check("submitting while an obsolete login prewarm stops queues a clean restart",
   /loginSubmitAfterPrewarmStop\s*=\s*true/.test(bodyOf("submitLogin"))

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -18,6 +18,7 @@ new Function("exports", fs.readFileSync(path.join(__dirname, "..", "BitwardenMod
   exports.unlockPrewarmCommand = unlockPrewarmCommand
   exports.emailLoginPrewarmCommand = emailLoginPrewarmCommand
   exports.apiKeyLoginCommand = apiKeyLoginCommand
+  exports.loginServerUrlFor = typeof loginServerUrlFor === "function" ? loginServerUrlFor : null
   exports.passwordEnvVar = passwordEnvVar
   exports.clientIdEnvVar = clientIdEnvVar
   exports.clientSecretEnvVar = clientSecretEnvVar
@@ -60,6 +61,20 @@ const CLIENT_ID = "user.11111111-2222-3333-4444-555555555555"
 const CLIENT_SECRET = "sEcReTcLiEnTsTrInG"
 const CODE = "249213"
 const SERVER = "https://vault.example.com"
+
+// Fixes #6. Cloud regions are distinct Bitwarden environments, while a
+// self-hosted installation still needs to retain the free-form server path.
+check("the login server selector maps US, EU and custom without conflating them",
+  Model.loginServerUrlFor
+    && Model.loginServerUrlFor("us", SERVER) === "https://vault.bitwarden.com"
+    && Model.loginServerUrlFor("eu", SERVER) === "https://vault.bitwarden.eu"
+    && Model.loginServerUrlFor("custom", `  ${SERVER}  `) === SERVER,
+  "US and EU must use their official vault URLs, and custom the entered URL")
+check("an invalid login server selection falls back to the safe US default",
+  Model.loginServerUrlFor
+    && Model.loginServerUrlFor("", SERVER) === "https://vault.bitwarden.com"
+    && Model.loginServerUrlFor("other", SERVER) === "https://vault.bitwarden.com",
+  "unknown region values must not turn a stale custom URL into a destination")
 
 check("only explicit Bitwarden second-factor challenges reveal the follow-up prompt",
   Model.loginNeedsSecondFactor
@@ -623,10 +638,23 @@ const syncFields = bodyOf("syncLoginFieldsToState")
 const submitDevice = bodyOf("submitDeviceVerification")
 const startDevice = bodyOf("startDeviceVerificationLogin")
 const loginFieldFocus = bodyOf("loginFieldHasFocus")
+const resolvedLoginServer = bodyOf("resolvedLoginServerUrl")
 const terminalLoginUi = panelSrc.slice(panelSrc.indexOf("// METHOD B: API Key"),
   panelSrc.indexOf("// SCREEN 2: LOCKED VIEW"))
 const emailLoginUi = panelSrc.slice(panelSrc.indexOf("// METHOD A: Email & Password"),
   panelSrc.indexOf("// METHOD B: API Key"))
+
+check("the login screen offers US, EU and Custom server choices to both login methods",
+  /text:\s*"US"[\s\S]{0,500}text:\s*"EU"[\s\S]{0,500}text:\s*"Custom"/.test(panelSrc)
+    && panelSrc.indexOf('text: "US"') < panelSrc.indexOf("// METHOD A: Email & Password"),
+  "the shared region selector must appear before the method-specific forms")
+check("the custom URL field appears only for the Custom server choice",
+  /id:\s*serverUrlField[\s\S]{0,160}visible:\s*root\.loginServerRegion\s*===\s*"custom"/.test(panelSrc),
+  "selecting US or EU must not expose a misleading self-hosted URL field")
+check("all login paths resolve their server choice through the same mapping",
+  /Model\.loginServerUrlFor\(loginServerRegion,\s*loginServerUrl\)/.test(resolvedLoginServer)
+    && (panelSrc.match(/resolvedLoginServerUrl\(\)/g) || []).length >= 4,
+  resolvedLoginServer || "resolvedLoginServerUrl() is missing")
 
 // Email/password login is deliberately two-stage. Asking every user for a
 // second factor up front makes an optional challenge look mandatory and
@@ -635,7 +663,8 @@ check("the email login initially hides the second-factor prompt",
   /Column\s*\{\s*visible:\s*root\.show2faField[\s\S]{0,420}TWO-STEP VERIFICATION CODE/.test(emailLoginUi),
   emailLoginUi)
 check("each login stage replaces the controls before it instead of overflowing below them",
-  (emailLoginUi.match(/visible:\s*root\.loginCredentialsStage/g) || []).length >= 3
+  (emailLoginUi.match(/visible:\s*root\.loginCredentialsStage/g) || []).length >= 2
+    && /visible:\s*root\.loginMethod\s*!==\s*"email"\s*\|\|\s*root\.loginCredentialsStage/.test(panelSrc)
     && /loginCredentialsStage:\s*!show2faField\s*&&\s*!show2faMethodPicker/.test(panelSrc)
     && /visible:\s*root\.show2faMethodPicker/.test(emailLoginUi)
     && /visible:\s*root\.show2faField/.test(emailLoginUi),

--- a/tests/sends.test.js
+++ b/tests/sends.test.js
@@ -137,6 +137,7 @@ for (const [name, build] of builders) {
 // --- terminal login handoff -------------------------------------------------
 const login = Model.terminalLoginCommand("login")[2]
 const unlock = Model.terminalLoginCommand("unlock")[2]
+const euLogin = Model.terminalLoginCommand("login", "https://vault.bitwarden.eu")[2]
 check("terminal login runs in a terminal", login.includes("omarchy launch terminal"), login.slice(0, 80))
 check("it falls back to a second terminal if the first is unavailable",
   login.includes("alacritty"), login.slice(0, 80))
@@ -151,6 +152,11 @@ check("neither mode probes with bw status",
   !login.includes("bw status") && !unlock.includes("bw status"), "expected no status probe")
 check("an unknown mode falls back to login",
   Model.terminalLoginCommand("")[2].includes("bw login --raw"), "expected login")
+check("terminal login configures an explicitly selected region before authenticating",
+  euLogin.includes("bw config server")
+    && euLogin.includes("https://vault.bitwarden.eu")
+    && euLogin.indexOf("bw config server") < euLogin.indexOf("bw login --raw"),
+  euLogin.slice(0, 300))
 // Only the method name crosses the IPC boundary; the key never does.
 check("a successful login reopens the panel",
   login.includes("omarchy-shell io.github.elevate08.qs-bitwarden-cli open"), login.slice(0, 300))


### PR DESCRIPTION
## Summary
- add explicit US and EU server presets to the login screen
- retain custom server support for self-hosted Bitwarden and Vaultwarden
- apply the selected server to email, API-key, and terminal login flows
- document the selector and add regression coverage

## Verification
- all JavaScript panel tests pass
- Rust test suite passes
- plugin manifest validation passes
- manually loaded the branch in the local Omarchy shell

Closes #6