### PR TITLE
fix: float transient notices instead of resizing the panel

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -15,7 +15,8 @@
 name: agent build
 
 on:
-  # Every push to master and every PR into it, with no `paths` filter.
+  # Every push to master or a release branch, and every PR into either, with
+  # no `paths` filter.
   #
   # There was one, naming agent/** and the build script, and it meant this
   # workflow never saw the panel: Panel.qml, BitwardenModel.js and tests/ were
@@ -28,10 +29,16 @@ on:
   # the digest check that compared a build with itself and the QML tests that
   # were all skipped. The reproducible-build job costs two minutes; filtering
   # it was never worth a hole this size.
+  #
+  # Release branches are listed for the same reason the paths filter came
+  # off. A release is assembled on one, so a PR into `release/1.7.0` that
+  # only master's branch list covered would merge with `no checks
+  # reported` -- the same hole reached through the base branch rather
+  # than through a path.
   push:
-    branches: [master]
+    branches: [master, 'release/**']
   pull_request:
-    branches: [master]
+    branches: [master, 'release/**']
   workflow_dispatch:
   # Callable as a reusable workflow. release.yml is the only caller: it runs
   # every gate below against a release tag before anything is published.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [1.7.0] - 2026-09-03
 
+### Fixed
+
+- Transient status and error messages now float at the bottom of the panel instead of changing its measured height, so updates such as a successful unlock no longer shift the active screen down and back up. Errors use the same compact notice surface and can be dismissed in place.
+
 ## [1.6.0] - 2026-08-31
 
 ### Added

--- a/Panel.qml
+++ b/Panel.qml
@@ -6318,74 +6318,6 @@ Panel {
         }
 
         // -------------------------------------------------------------------
-        // Flash Message Banner
-        // -------------------------------------------------------------------
-        BorderSurface {
-          visible: root.flashMessage !== "" && !root.totpFollowupActive
-          width: parent.width
-          implicitHeight: flashText.implicitHeight + Style.space(10)
-          color: Util.alpha(Color.accent, 0.15)
-          radius: Style.cornerRadius
-          borderSpec: Border.surfaceSpec("menu", "border", Color.accent, 1)
-
-          Row {
-            anchors.centerIn: parent
-            spacing: Style.space(8)
-            Text {
-              textFormat: Text.PlainText
-              text: "󰄬"
-              color: Color.accent
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.body
-            }
-            Text {
-              textFormat: Text.PlainText
-              id: flashText
-              text: root.flashMessage
-              color: root.fg
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
-              font.bold: true
-            }
-          }
-        }
-
-        // -------------------------------------------------------------------
-        // Error Message Banner
-        // -------------------------------------------------------------------
-        BorderSurface {
-          visible: root.errorMessage !== ""
-          width: parent.width
-          implicitHeight: errorText.implicitHeight + Style.space(12)
-          color: Util.alpha(Color.urgent, 0.15)
-          radius: Style.cornerRadius
-          borderSpec: Border.surfaceSpec("menu", "border", Color.urgent, 1)
-
-          Row {
-            anchors.centerIn: parent
-            width: parent.width - Style.space(16)
-            spacing: Style.space(8)
-            Text {
-              textFormat: Text.PlainText
-              text: "󰅚"
-              color: Color.urgent
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.body
-            }
-            Text {
-              textFormat: Text.PlainText
-              id: errorText
-              text: root.errorMessage
-              color: root.fg
-              font.family: root.fontFamily
-              font.pixelSize: Style.font.bodySmall
-              wrapMode: Text.Wrap
-              width: parent.width - Style.space(24)
-            }
-          }
-        }
-
-        // -------------------------------------------------------------------
         // Development Helper Banner
         // -------------------------------------------------------------------
         // The shipped helper is what a user installed and what CI verified.
@@ -10363,6 +10295,23 @@ Panel {
             }
           }
         }
+      }
+
+      // Transient updates belong to the panel, but not to its layout. Keeping
+      // this beside mainColumn means fittedContentHeight never sees it, so an
+      // unlock, copy, save, or error cannot shove the active screen down and
+      // pull it back up when the message clears.
+      StatusNotice {
+        id: statusNotice
+        statusMessage: root.flashMessage
+        errorMessage: root.errorMessage
+        statusSuppressed: root.totpFollowupActive
+        foreground: root.fg
+        surfaceColor: root.bar ? root.bar.background : Color.background
+        accentColor: root.accent
+        urgentColor: root.urgent
+        fontFamily: root.fontFamily
+        onErrorDismissed: root.errorMessage = ""
       }
     }
   }

--- a/StatusNotice.qml
+++ b/StatusNotice.qml
@@ -1,0 +1,110 @@
+import QtQuick
+import qs.Commons
+import qs.Ui
+
+// A transient panel-local notice. It anchors to its parent as an overlay and
+// deliberately reports no height to the parent's content layout.
+BorderSurface {
+  id: root
+
+  required property string statusMessage
+  required property string errorMessage
+  required property bool statusSuppressed
+  required property color foreground
+  required property color surfaceColor
+  required property color accentColor
+  required property color urgentColor
+  required property string fontFamily
+
+  readonly property bool showsError: root.errorMessage !== ""
+  readonly property bool showsStatus: root.statusMessage !== "" && !root.statusSuppressed
+  readonly property bool shown: showsError || showsStatus
+  readonly property color tone: showsError ? root.urgentColor : root.accentColor
+
+  signal errorDismissed()
+
+  anchors.horizontalCenter: parent.horizontalCenter
+  anchors.bottom: parent.bottom
+  anchors.bottomMargin: Style.space(10)
+  width: Math.min(parent.width - Style.space(20), Style.space(390))
+  implicitHeight: noticeRow.implicitHeight + Style.space(16)
+  z: 20
+  visible: opacity > 0
+  enabled: shown
+  opacity: shown ? 1 : 0
+  color: root.surfaceColor
+  radius: Style.cornerRadius
+  borderSpec: Border.surfaceSpec("menu", "border", root.tone, 1)
+
+  Accessible.role: Accessible.AlertMessage
+  Accessible.name: (root.showsError ? "Needs attention: " : "Status: ") + noticeMessage.text
+  Accessible.ignored: !root.shown
+
+  Behavior on opacity {
+    NumberAnimation { duration: 140; easing.type: Easing.OutQuad }
+  }
+
+  // Consume pointer presses on the floating surface so covered controls
+  // cannot be activated through it.
+  MouseArea {
+    anchors.fill: parent
+    acceptedButtons: Qt.AllButtons
+  }
+
+  Row {
+    id: noticeRow
+    anchors.fill: parent
+    anchors.margins: Style.space(8)
+    spacing: Style.space(8)
+
+    Text {
+      textFormat: Text.PlainText
+      id: noticeIcon
+      anchors.verticalCenter: parent.verticalCenter
+      text: root.showsError ? "󰅚" : "󰋼"
+      color: root.tone
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.body
+    }
+
+    Column {
+      anchors.verticalCenter: parent.verticalCenter
+      width: parent.width - noticeIcon.implicitWidth - Style.space(8)
+        - (dismissNoticeButton.visible
+          ? dismissNoticeButton.implicitWidth + Style.space(8)
+          : 0)
+      spacing: Style.space(2)
+
+      Text {
+        textFormat: Text.PlainText
+        width: parent.width
+        text: root.showsError ? "NEEDS ATTENTION" : "STATUS"
+        color: root.tone
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        font.bold: true
+      }
+
+      Text {
+        textFormat: Text.PlainText
+        id: noticeMessage
+        width: parent.width
+        text: root.showsError ? root.errorMessage : root.statusMessage
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        wrapMode: Text.Wrap
+      }
+    }
+
+    PanelActionButton {
+      id: dismissNoticeButton
+      visible: root.showsError
+      anchors.verticalCenter: parent.verticalCenter
+      iconText: "󰅖"
+      tooltipText: "Dismiss message"
+      fontFamily: root.fontFamily
+      onClicked: root.errorDismissed()
+    }
+  }
+}

--- a/tests/rich-text.test.js
+++ b/tests/rich-text.test.js
@@ -53,7 +53,7 @@ check("plainLabel is idempotent in the sense that re-running it cannot inject",
 // Text defaults to Text.AutoText. Vault names, usernames, URIs, notes and Send
 // names all land in one of these, so every one of them has to say otherwise --
 // including the ones that only render a constant today.
-for (const file of ["Panel.qml", "SshAgentSettings.qml", "SshApprovalScreen.qml", "FormPickerRow.qml"]) {
+for (const file of ["Panel.qml", "SshAgentSettings.qml", "SshApprovalScreen.qml", "FormPickerRow.qml", "StatusNotice.qml"]) {
   const src = fs.readFileSync(path.join(__dirname, "..", file), "utf8").split("\n")
   const bare = []
   src.forEach((line, i) => {
@@ -68,7 +68,7 @@ for (const file of ["Panel.qml", "SshAgentSettings.qml", "SshApprovalScreen.qml"
 // The kit's Button builds its own Text and exposes no textFormat, so the
 // strings we hand it have to arrive already neutralized.
 // Every QML file that draws vault-derived text, not just the largest one.
-const panel = ["Panel.qml", "SshAgentSettings.qml", "SshApprovalScreen.qml", "FormPickerRow.qml"]
+const panel = ["Panel.qml", "SshAgentSettings.qml", "SshApprovalScreen.qml", "FormPickerRow.qml", "StatusNotice.qml"]
   .map(file => fs.readFileSync(path.join(__dirname, "..", file), "utf8"))
   .join("\n")
 for (const binding of ["formFolderLabel()", "formOrgLabel()", 'modelData.name + ": " + modelData.value']) {

--- a/tests/ssh-agent-artifact.test.js
+++ b/tests/ssh-agent-artifact.test.js
@@ -251,9 +251,17 @@ check("drift is still fatal on a same-repository run",
 // with `no checks reported`. Both halves are asserted, because fixing one
 // leaves the hole open.
 check("CI runs against master, where the code now lands",
-  /push:\s*\n\s*branches:\s*\[master\]/.test(workflow)
-    && /pull_request:\s*\n\s*branches:\s*\[master\]/.test(workflow),
+  /push:\s*\n\s*branches:\s*\[master[,\]]/.test(workflow)
+    && /pull_request:\s*\n\s*branches:\s*\[master[,\]]/.test(workflow),
   "the workflow does not run on master pushes and master PRs")
+// A release is assembled on a release branch before it is tagged, so the same
+// gates have to cover it. Listing master alone let a PR into `release/1.7.0`
+// merge with `no checks reported` -- PR #13's hole reached through the base
+// branch instead of through a paths filter.
+check("CI runs against release branches too, where a release is assembled",
+  /push:\s*\n\s*branches:\s*\[[^\]]*'release\/\*\*'/.test(workflow)
+    && /pull_request:\s*\n\s*branches:\s*\[[^\]]*'release\/\*\*'/.test(workflow),
+  "the workflow does not run on release-branch pushes and PRs into them")
 check("no paths filter decides which changes are checked",
   !/^\s*paths:/m.test(workflow),
   "a paths filter is how the panel went unchecked; these gates are cheap enough to always run")

--- a/tests/status-notice.test.js
+++ b/tests/status-notice.test.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Transient status and error messages float over the panel instead of joining
+// its content column. Their arrival must never change the height used by
+// KeyboardPanel, which is what made every screen jump down and back up.
+//
+//   node tests/status-notice.test.js
+
+const fs = require("fs")
+const path = require("path")
+
+const panelSrc = fs.readFileSync(path.join(__dirname, "..", "Panel.qml"), "utf8")
+const noticeSrc = fs.existsSync(path.join(__dirname, "..", "StatusNotice.qml"))
+  ? fs.readFileSync(path.join(__dirname, "..", "StatusNotice.qml"), "utf8")
+  : ""
+let pass = 0
+const failures = []
+const check = (label, ok, detail) => ok ? pass++ : failures.push(`${label}\n    ${detail}`)
+
+const noticeAt = panelSrc.indexOf("id: statusNotice")
+const noticeUse = noticeAt === -1 ? "" : panelSrc.slice(noticeAt, noticeAt + 1000)
+
+check("the status notice is a sibling overlay rather than a mainColumn child",
+  /^      StatusNotice \{\n        id: statusNotice/m.test(panelSrc),
+  "expected statusNotice at PanelKeyCatcher child indentation")
+check("the overlay is pinned inside the bottom of the panel",
+  /anchors\.bottom:\s*parent\.bottom/.test(noticeSrc)
+    && /anchors\.horizontalCenter:\s*parent\.horizontalCenter/.test(noticeSrc)
+    && /z:\s*[1-9][0-9]*/.test(noticeSrc),
+  noticeSrc)
+check("the overlay never participates in panel height measurement",
+  /contentHeight:\s*panel\.fittedContentHeight\(mainColumn\.implicitHeight/.test(panelSrc)
+    && !/implicitHeight:\s*statusNotice/.test(panelSrc),
+  "KeyboardPanel must continue to measure only mainColumn")
+
+check("errors take priority over transient status text",
+  /showsError:\s*root\.errorMessage\s*!==\s*""/.test(noticeSrc)
+    && /text:\s*root\.showsError\s*\?\s*root\.errorMessage\s*:\s*root\.statusMessage/.test(noticeSrc),
+  noticeSrc)
+check("status text still yields to the sequential TOTP action",
+  /showsStatus:[^\n]*root\.statusMessage\s*!==\s*""[^\n]*!root\.statusSuppressed/.test(noticeSrc)
+    && /statusSuppressed:\s*root\.totpFollowupActive/.test(noticeUse),
+  noticeSrc + "\n" + noticeUse)
+check("long messages wrap within the panel",
+  /wrapMode:\s*Text\.Wrap/.test(noticeSrc), noticeSrc)
+check("errors can be dismissed without hiding ordinary status updates",
+  /visible:\s*root\.showsError/.test(noticeSrc)
+    && /onClicked:\s*root\.errorDismissed\(\)/.test(noticeSrc)
+    && /onErrorDismissed:\s*root\.errorMessage\s*=\s*""/.test(noticeUse),
+  noticeSrc + "\n" + noticeUse)
+check("dynamic notices expose alert semantics to assistive technology",
+  /Accessible\.role:\s*Accessible\.AlertMessage/.test(noticeSrc)
+    && /Accessible\.ignored:\s*!root\.shown/.test(noticeSrc)
+    && /Accessible\.name:/.test(noticeSrc),
+  noticeSrc)
+
+console.log(`${pass} passed, ${failures.length} failed`)
+if (failures.length) {
+  console.error("\nFAILURES:\n  " + failures.join("\n  "))
+  process.exit(1)
+}


### PR DESCRIPTION
## What

The flash and error banners lived inside `mainColumn`, so every transient message counted toward the panel's measured content height. A successful unlock pushed the screen below it down by the banner's height and pulled it back up when the message cleared; an error did the same in reverse — a layout jump on exactly the frames a user is reading the panel.

`StatusNotice.qml` replaces both banners with one floating surface. It is a **sibling** of `mainColumn`, not a child, anchored to the bottom of the panel above the content, so `fittedContentHeight` never sees it and no message can move the screen.

- One surface, two tones: accent border for a status, urgent border for an error.
- Fades in and out rather than appearing between frames.
- An error is dismissible in place instead of waiting out its timer.
- A `MouseArea` over the surface keeps a press from reaching the controls it floats above.
- `Accessible.role: AlertMessage`, announced on appearance and ignored when not shown.

## Also in this PR

`agent-build.yml` triggered on `master` alone, so this PR — into `release/1.7.0` — would have merged with `no checks reported`. That is the hole the workflow already carries a comment about, arriving through the base branch instead of through a `paths` filter. `release/**` now joins master on both the `push` and `pull_request` lists, and `tests/ssh-agent-artifact.test.js` asserts both halves so it cannot silently regress.

## Verification

- All 32 panel test files pass locally, including the new `tests/status-notice.test.js`.
- `StatusNotice.qml` is added to the `rich-text.test.js` file lists: it draws message text, and every QML file that does has to declare `textFormat` rather than inherit `Text.AutoText`.
- `bin/SHA256SUMS` verifies; no helper bytes touched.
- Run live via a symlinked worktree against the real Omarchy shell — no QML load errors, notices float without shifting the active screen.

## Base

Targets `release/1.7.0`, which carries only the version bump (`manifest.json`, README badge, empty CHANGELOG heading). This PR fills that heading's `### Fixed` section. The tag is cut from the release branch once everything for 1.7.0 has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)