### PR TITLE
ci: install cargo-deny instead of building it

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -236,6 +236,12 @@ jobs:
         # per address and GitHub-hosted runners share addresses, so that route
         # fails on someone else's traffic and reports it as our dependency
         # gate going down. The redirect carries no such budget.
+        #
+        # `shell: bash` is explicit because a job running in a container gets
+        # `sh -e` by default, which is dash here -- and dash has no `pipefail`,
+        # so the guard on the line below is itself what fails. Every other step
+        # in this job is a single command and never noticed.
+        shell: bash
         run: |
           set -euo pipefail
           latest="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -217,8 +217,49 @@ jobs:
         # database, and an old copy fails to parse newer entries. It is
         # checking dependencies, not producing artifact bytes, so currency
         # matters more here than reproducibility.
+        #
+        # The published binary, not `cargo install`. Building this tool from
+        # source cost 1m58s of a 3m34s job -- more than half the critical path
+        # of every push and every PR -- to produce a checker that then ran in
+        # about a second. Downloading it takes well under one. Currency is
+        # unaffected: the advisory database is fetched at check time, not baked
+        # into the binary, so `latest` here means the same thing it meant when
+        # cargo built it.
+        #
+        # Resolved at run time rather than pinned, for that same currency, and
+        # verified against the digest published beside it. Upstream ships a
+        # static musl build, so it runs in this container regardless of what
+        # the container's glibc is.
+        #
+        # The version comes from the `releases/latest` redirect rather than
+        # from api.github.com. The API allows 60 unauthenticated calls an hour
+        # per address and GitHub-hosted runners share addresses, so that route
+        # fails on someone else's traffic and reports it as our dependency
+        # gate going down. The redirect carries no such budget.
         run: |
-          cargo install cargo-deny --locked
+          set -euo pipefail
+          latest="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+            https://github.com/EmbarkStudios/cargo-deny/releases/latest)"
+          version="${latest##*/}"
+          # A redirect that stopped redirecting would leave a path segment
+          # rather than a version, and the download would 404 with nothing
+          # saying why. Check the shape before trusting it.
+          case "$version" in
+            [0-9]*.[0-9]*) : ;;
+            *) echo "::error::could not resolve the latest cargo-deny release (got '$version' from '$latest')"; exit 1 ;;
+          esac
+          base="https://github.com/EmbarkStudios/cargo-deny/releases/download/$version"
+          archive="cargo-deny-$version-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL -o "$archive" "$base/$archive"
+          curl -fsSL -o "$archive.sha256" "$base/$archive.sha256"
+          # Upstream publishes the bare digest, so pair it with the filename
+          # before sha256sum will read it. A mismatch stops the job here.
+          echo "$(cat "$archive.sha256")  $archive" | sha256sum -c -
+          tar -xzf "$archive" --strip-components=1 -C /usr/local/cargo/bin \
+            "cargo-deny-$version-x86_64-unknown-linux-musl/cargo-deny"
+          # Say which build actually did the checking, the way the QML step
+          # records its Qt packages.
+          cargo-deny --version
           cargo deny --manifest-path agent/Cargo.toml --config deny.toml check
 
       - name: Tests


### PR DESCRIPTION
Half the wall time of every push and every PR was spent building a tool, not using it.

## The measurement

`agent build`'s three jobs run in parallel, so wall time is the slowest. From run `33828270850`:

| job | time |
|---|---|
| **tests, format and lint** | **220s** — critical path |
| byte-identical across build paths | 123s |
| panel tests | 84s |

Within the critical path, one step dominates:

| step | time |
|---|---|
| **Dependency and licence policy** | **119s** |
| Tests | 63s |
| Initialize containers | 18s |
| Lint | 13s |
| Formatting | <3s |

And from that step's own log:

```
Compiling cargo-deny v0.20.2
Finished `release` profile [optimized] target(s) in 1m 58s
Installed package `cargo-deny v0.20.2`
```

**118 of the 119 seconds are compiling cargo-deny.** The policy check it then performs takes about a second.

## The change

Upstream publishes a static musl binary with a digest beside it. Running the new step verbatim against the real `deny.toml`:

```
cargo-deny-0.20.2-x86_64-unknown-linux-musl.tar.gz: OK
cargo-deny 0.20.2
advisories ok, bans ok, licenses ok, sources ok

real    0m1.742s
```

**119s → ~2s.** Expected effect: `gates` ~214s → ~100s, making `byte-identical` (123s) the new critical path, so runs land around 125s instead of 250s. `release.yml` calls this workflow as its gates stage, so it saves the same 118s.

## On the "not version-pinned, deliberately" comment

That comment is still correct and still honoured — the version is resolved at run time, so the checker stays exactly as current as `cargo install` kept it.

Worth noting the reasoning was slightly over-broad, though: it argues currency is needed because the tool "reads a live advisory database, and an old copy fails to parse newer entries". The database is fetched *when the check runs*, not baked into the binary, so how the binary arrived never affected advisory freshness. Currency and this change were never in tension.

## Two things I hit while writing it

- **`api.github.com` would have made this flaky.** It allows 60 unauthenticated calls per hour per address, and GitHub-hosted runners share addresses (`x-ratelimit-limit: 60`, confirmed). That fails on other people's traffic and reports it as this repo's dependency gate going down. The version now comes from the `releases/latest` redirect, which carries no such budget, and is shape-checked before use — a redirect that stopped redirecting would otherwise 404 the download with nothing in the log explaining why.
- **No new action dependency.** Every `uses:` in this repository is first-party `actions/*`. `EmbarkStudios/cargo-deny-action` and `taiki-e/install-action` would both have done the job, but a checked `curl` keeps the trust surface where it is — which seemed worth preserving in a repo whose binary handles decrypted private keys.

The archive is verified against its published digest before anything is unpacked, and the binary prints its version into the log the way the QML step records its Qt package versions.

## Not addressed here

Two further findings from the same review, deliberately left out:

- **No Rust caching.** `Swatinem/rust-cache` on `gates` would cut `Tests` further — but it must never go on `byte-identical`, where a warm `target/` would defeat the point of proving the bytes rebuild from clean. Smaller win than it looks, since that job becomes the critical path after this change.
- **Rust jobs run on QML/docs-only PRs.** The `paths:` filter was removed for good reason and should stay off. But a *job-level* `if:` differs from a workflow-level filter in a way that matters: a skipped job still reports a conclusion and satisfies branch protection, whereas a workflow that never triggers reports nothing — which was the `no checks reported` hole from #13. Worth considering separately, and only with conservative detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
