### PR TITLE
release: v1.7.1

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -236,6 +236,12 @@ jobs:
         # per address and GitHub-hosted runners share addresses, so that route
         # fails on someone else's traffic and reports it as our dependency
         # gate going down. The redirect carries no such budget.
+        #
+        # `shell: bash` is explicit because a job running in a container gets
+        # `sh -e` by default, which is dash here -- and dash has no `pipefail`,
+        # so the guard on the line below is itself what fails. Every other step
+        # in this job is a single command and never noticed.
+        shell: bash
         run: |
           set -euo pipefail
           latest="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -217,8 +217,49 @@ jobs:
         # database, and an old copy fails to parse newer entries. It is
         # checking dependencies, not producing artifact bytes, so currency
         # matters more here than reproducibility.
+        #
+        # The published binary, not `cargo install`. Building this tool from
+        # source cost 1m58s of a 3m34s job -- more than half the critical path
+        # of every push and every PR -- to produce a checker that then ran in
+        # about a second. Downloading it takes well under one. Currency is
+        # unaffected: the advisory database is fetched at check time, not baked
+        # into the binary, so `latest` here means the same thing it meant when
+        # cargo built it.
+        #
+        # Resolved at run time rather than pinned, for that same currency, and
+        # verified against the digest published beside it. Upstream ships a
+        # static musl build, so it runs in this container regardless of what
+        # the container's glibc is.
+        #
+        # The version comes from the `releases/latest` redirect rather than
+        # from api.github.com. The API allows 60 unauthenticated calls an hour
+        # per address and GitHub-hosted runners share addresses, so that route
+        # fails on someone else's traffic and reports it as our dependency
+        # gate going down. The redirect carries no such budget.
         run: |
-          cargo install cargo-deny --locked
+          set -euo pipefail
+          latest="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+            https://github.com/EmbarkStudios/cargo-deny/releases/latest)"
+          version="${latest##*/}"
+          # A redirect that stopped redirecting would leave a path segment
+          # rather than a version, and the download would 404 with nothing
+          # saying why. Check the shape before trusting it.
+          case "$version" in
+            [0-9]*.[0-9]*) : ;;
+            *) echo "::error::could not resolve the latest cargo-deny release (got '$version' from '$latest')"; exit 1 ;;
+          esac
+          base="https://github.com/EmbarkStudios/cargo-deny/releases/download/$version"
+          archive="cargo-deny-$version-x86_64-unknown-linux-musl.tar.gz"
+          curl -fsSL -o "$archive" "$base/$archive"
+          curl -fsSL -o "$archive.sha256" "$base/$archive.sha256"
+          # Upstream publishes the bare digest, so pair it with the filename
+          # before sha256sum will read it. A mismatch stops the job here.
+          echo "$(cat "$archive.sha256")  $archive" | sha256sum -c -
+          tar -xzf "$archive" --strip-components=1 -C /usr/local/cargo/bin \
+            "cargo-deny-$version-x86_64-unknown-linux-musl/cargo-deny"
+          # Say which build actually did the checking, the way the QML step
+          # records its Qt packages.
+          cargo-deny --version
           cargo deny --manifest-path agent/Cargo.toml --config deny.toml check
 
       - name: Tests

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -310,10 +310,18 @@ jobs:
           # -- but narrowly, loudly, and only for that reason: a gate that
           # quietly runs nothing is worse than no gate, and this file has
           # already been bitten twice by checks passing through absence.
+          #
+          # The match is on the `import` line, not on the path anywhere in the
+          # file. It used to be the latter, and that is a third way to pass
+          # through absence: tst_row_widths.qml only *mentions* the kit, in an
+          # optional check that reads Ui/Button.qml if it happens to be there
+          # and returns quietly if it is not. A substring match skipped the
+          # whole file, so the row-width gate silently stopped running on every
+          # runner while still reporting success.
           shopt -s nullglob
           run=() ; skipped=()
           for f in tests/qml/*.qml; do
-            if grep -q "/usr/share/omarchy/shell" "$f" && [ ! -d /usr/share/omarchy/shell/Ui ]; then
+            if grep -q 'import "file:/usr/share/omarchy/shell' "$f" && [ ! -d /usr/share/omarchy/shell/Ui ]; then
               skipped+=("$f")
             else
               run+=("$f")
@@ -327,9 +335,15 @@ jobs:
             exit 1
           fi
           echo "running ${#run[@]} QML test file(s), skipping ${#skipped[@]}"
+          # QML_XHR_ALLOW_FILE_READ lets a test read the repository's own QML
+          # back through XMLHttpRequest, which Qt refuses by default.
+          # tst_row_widths.qml needs it: it measures the real panel sources
+          # rather than a copy of them that could drift. Without it that file
+          # fails on its first check rather than measuring nothing.
           status=0
           for f in "${run[@]}"; do
-            QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner -input "$f" || status=1
+            QML_XHR_ALLOW_FILE_READ=1 QT_QPA_PLATFORM=offscreen \
+              /usr/lib/qt6/bin/qmltestrunner -input "$f" || status=1
           done
           exit $status
 

--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -35,10 +35,24 @@ on:
   # only master's branch list covered would merge with `no checks
   # reported` -- the same hole reached through the base branch rather
   # than through a path.
+  #
+  # Master is deliberately NOT listed, and that is not the same mistake in
+  # reverse. Work reaches master only by merging a release branch, and master
+  # requires that branch to be up to date before it can -- so the tree master
+  # ends up with is the tree this workflow already passed on the release
+  # branch, at the commit it passed on. Running again on the push would check
+  # the same tree twice, and running on the pull request would check a merge
+  # preview of it that cannot differ. The one thing master does need is
+  # publication, which is publish-on-master.yml.
+  #
+  # The exposure this accepts, stated plainly: a pull request into master from
+  # something other than a release branch gets no checks. Nothing mechanically
+  # prevents one. It is the release branches that are gated, so that is the
+  # route work has to take.
   push:
-    branches: [master, 'release/**']
+    branches: ['release/**']
   pull_request:
-    branches: [master, 'release/**']
+    branches: ['release/**']
   workflow_dispatch:
   # Callable as a reusable workflow. release.yml is the only caller: it runs
   # every gate below against a release tag before anything is published.

--- a/.github/workflows/publish-on-master.yml
+++ b/.github/workflows/publish-on-master.yml
@@ -1,0 +1,119 @@
+# The one thing that happens when work reaches master.
+#
+# A release is built, verified, attested and assembled on its release branch,
+# where the tag is pushed -- see release.yml, which leaves the result as a
+# draft. Nothing is rebuilt here and nothing is re-verified: the commit master
+# now holds is the commit that was already checked, and checking it a second
+# time would only prove the runner is deterministic.
+#
+# What is missing at that point is publication. A tag on a release branch is a
+# candidate; the same commit on master is the release. This flips the draft,
+# and does nothing else.
+#
+# It follows that master carries no other workflow. agent-build.yml runs on
+# release branches and on pull requests into them, not here.
+
+name: publish on master
+
+on:
+  push:
+    branches: [master]
+  # Publishing is idempotent -- an already-published release is left alone --
+  # so a run can be repeated by hand if a push happened while this was broken.
+  workflow_dispatch:
+
+# The only write this repository's CI does, and it writes releases rather than
+# code: no branch, no tag and no tracked file is touched from here.
+permissions:
+  contents: write
+
+concurrency:
+  # Two merges in quick succession must not race to publish the same draft.
+  # Never cancelled: a half-published release is worse than a queued one.
+  group: publish-on-master
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: take the release out of draft
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out master
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags. The tag this is looking for is reachable
+          # from the merge, not pointing at it, and a shallow clone cannot see
+          # far enough back to find it.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Publish the release this merge brought in
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # Which tagged commits did THIS push put on master? Answered by
+          # comparing what is reachable now with what was reachable before it,
+          # rather than by asking which tag is nearest.
+          #
+          # `git describe` was the obvious way and it is wrong here. Merging a
+          # release branch makes the tag a parent of master's new tip rather
+          # than the tip itself, and describe resolves the resulting tie by
+          # first-parent depth -- so on a merge commit it walks back into the
+          # base and reports the PREVIOUS release. It picked v1.0.0 over v1.7.1
+          # in exactly this shape. `git tag --points-at HEAD` fails the other
+          # way: it finds nothing at all unless the merge fast-forwarded.
+          #
+          # A reachability difference has neither failure. It is exact on a
+          # merge commit and on a fast-forward alike, and it publishes nothing
+          # that was already on master.
+          git tag --merged HEAD --list 'v*' | sort > /tmp/tags-now
+
+          if [ -n "${BEFORE:-}" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ] \
+             && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            git tag --merged "$BEFORE" --list 'v*' | sort > /tmp/tags-before
+          else
+            # First push to the branch, a force-push, or a dispatch run: there
+            # is no previous state to difference against. Fall back to every
+            # reachable tag and let the draft check below decide -- anything
+            # already published is left alone, so the worst case is a no-op.
+            echo "::notice::no usable before-state; considering every reachable tag"
+            : > /tmp/tags-before
+          fi
+
+          arrived="$(comm -23 /tmp/tags-now /tmp/tags-before)"
+          if [ -z "$arrived" ]; then
+            echo "::notice::this push brought no new v* tag onto master; nothing to publish"
+            exit 0
+          fi
+          echo "tags newly on master: $(echo $arrived)"
+
+          published=0
+          for tag in $arrived; do
+            if ! gh release view "$tag" >/dev/null 2>&1; then
+              # A tag can reach master with no release behind it -- an old one
+              # from before this workflow existed, or one pushed by hand. Not
+              # an error, and emphatically not something to invent a release
+              # for: the assets and the attestation are made on the release
+              # branch by release.yml, or not at all.
+              echo "::notice::no release exists for $tag; skipping"
+              continue
+            fi
+            if [ "$(gh release view "$tag" --json isDraft --jq .isDraft)" != "true" ]; then
+              echo "::notice::release $tag is already published; skipping"
+              continue
+            fi
+            # A release is a claim about what the default branch contains.
+            # Belt and braces on top of the reachability difference above.
+            if ! git merge-base --is-ancestor "$tag^{commit}" HEAD; then
+              echo "::error::$tag is not an ancestor of master; refusing to publish"
+              exit 1
+            fi
+            gh release edit "$tag" --draft=false
+            gh release view "$tag" --json isDraft,url --jq '"published \(.url) (isDraft=\(.isDraft))"'
+            published=$((published + 1))
+          done
+          echo "::notice::published $published release(s)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,10 +340,18 @@ jobs:
                   bin/x86_64-linux/qs-bitwarden-ssh-agent)
           prerelease=()
           case "$TAG" in *-*) prerelease=(--prerelease) ;; esac
+          # Created as a draft. A tag is pushed on a release branch, before
+          # that work has reached master, and a published release at that
+          # moment would be announcing a version the default branch does not
+          # yet contain. publish-on-master.yml takes the draft public when the
+          # tagged commit lands on master, which is the moment the release is
+          # real. Everything that costs anything -- the gates, the reports, the
+          # attestation, the assets -- has already happened here, on the
+          # release branch, where it belongs.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "::notice::release $TAG exists; uploading assets to it"
             gh release upload "$TAG" "${assets[@]}" --clobber
           else
-            gh release create "$TAG" "${assets[@]}" \
+            gh release create "$TAG" "${assets[@]}" --draft \
               --title "$TAG" --notes-file "$notes" "${prerelease[@]}"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,9 +272,21 @@ jobs:
     # what makes it safe to rehearse.
     if: github.ref_type == 'tag'
     runs-on: ubuntu-24.04
-    # The protection boundary. `release` requires a reviewer's approval before
-    # this job starts, and it is the only job in the repository that asks for
-    # anything beyond read.
+    # The protection boundary, and still the only job in the repository that
+    # asks for anything beyond read.
+    #
+    # It used to also require a reviewer to click approve here. That was a
+    # third human gate on a path that already has two, and the wrong two to
+    # add it to: the work was reviewed on the release branch, where the PRs
+    # are and where the gates run, and the tag that reaches this job is pushed
+    # deliberately. What this job produces is a draft, so approving it was not
+    # even the moment anything went public -- that is the merge to master,
+    # which is itself a pull request.
+    #
+    # The environment stays, for what it does rather than for the click: it
+    # scopes these permissions to this one job, records the deployment, and
+    # carries a branch policy that lets only `v*` tags reach it -- so a branch
+    # cannot deploy here however the workflow is triggered.
     environment:
       name: release
       url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}

--- a/BitwardenModel.js
+++ b/BitwardenModel.js
@@ -6036,3 +6036,25 @@ function plainLabel(value) {
     + text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
     + "</span>"
 }
+
+// A vault value is any length the user typed, and Ui.Button sizes itself to
+// its label with no elide of its own -- so a folder named after a whole client
+// engagement makes one button wider than the panel, which a wrapping row
+// cannot rescue because it can only move a control to the next line, never
+// shrink one. Clip the value first, so the widest a button can get is bounded
+// by us rather than by the vault.
+//
+// Characters rather than pixels: the shell's font is `monospace` by default,
+// so a count is a width, and a clip that reads the font would have to run in
+// QML where it cannot be tested. The ellipsis is inside the budget, so `max`
+// is the true ceiling.
+//
+// Runs BEFORE plainLabel(). Afterwards the string may be wrapped in a <span>,
+// and slicing that would cut a tag in half and hand markup to the control.
+function clipLabel(value, max) {
+  var text = (value === undefined || value === null) ? "" : String(value)
+  var limit = Math.max(1, Math.floor(Number(max) || 0))
+  if (text.length <= limit) return text
+  if (limit <= 3) return text.slice(0, limit)
+  return text.slice(0, limit - 3) + "..."
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.7.1] - 2026-09-04
+
+### Fixed
+
+- **A button could be laid out past the edge of the panel and vanish.** Opening an item while the panel recognised the active window added a fourth button -- **Suggested here** -- to the detail header, and that header was a `Row`: a positioner that can neither shrink a control nor start a second line, so the fourth pushed **Delete** off the panel entirely. It went only once the suggestion was pinned, because "Suggested here" is one character wider than "Suggest here", and that character was the one that overflowed. The header wraps now rather than overflowing, and **Back to list (Esc)** is **Back (Esc)** -- what the Sends screen already called it, and enough on its own to keep all four on one line.
+- **The folder, organization and type filters had the same fault and worse odds.** Their labels carry vault names of no fixed length, and the row is centred, so a long folder or organization name spilled off both edges at once -- and it did not take an unusual name: *Unfiled / Personal / Favorites* was already over. The row wraps too, and stays centred while the three fit a line. A name past twenty characters is clipped, with the whole of it still in the tooltip: a wrapping row can move a button to the next line but can never make one narrower than the panel, so the clip is the only thing that bounds a single button.
+- The SSH agent's client-routing buttons in Settings could overflow the same way, if the four that share that row were ever shown together.
+- **Seven spacers meant to push a control to the right-hand edge were doing nothing at all.** `Item { Layout.fillWidth: true }` is a QtQuick.Layouts instruction, and these sat inside plain `Row`s, which ignore it -- so each laid out at zero width and the control after it stopped short. The countdown beside **VERIFICATION CODE (TOTP)** sat against the heading instead of at the margin, and so did the controls beside **ATTACHMENTS**, **NOTES** and **PASSWORD**. Those rows are `RowLayout`s now, which is what the spacers were written for.
+
 ## [1.7.0] - 2026-09-03
 
 ### Added

--- a/Panel.qml
+++ b/Panel.qml
@@ -60,6 +60,42 @@ Panel {
     wrapMode: Text.WordWrap
   }
 
+  // One of the three vault filters at the foot of the list, collapsed to its
+  // current value. Declared once so the three cannot drift apart and start
+  // reading as different kinds of control.
+  //
+  // The button names its filter as well as showing its value. The glyphs alone
+  // do not carry it: the three sit together reading "All", "All", "All" for as
+  // long as nothing is filtered, which is exactly when the value says least and
+  // the name says most. So the name stays, and the row is allowed to take a
+  // second line on the rarer occasions all three are set to something long.
+  //
+  // The value is still clipped. `Ui.Button` has no elide, so a folder named
+  // after a whole client engagement would make one button wider than the whole
+  // panel -- and a row that wraps can move a button to the next line but can
+  // never make one narrower than the panel it is in.
+  component VaultFilterButton: Button {
+    required property string group
+    required property string glyph
+    required property string name
+    required property string value
+    required property string shortcut
+
+    // Clipped first, then neutralized: plainLabel may return a <span>, and
+    // slicing that would cut the tag in half.
+    text: Model.plainLabel(name + ": " + Model.clipLabel(value, 20))
+    iconText: root.openFilterGroup === group ? "󰅀" : glyph
+    selected: root.openFilterGroup === group
+    accent: Color.accent
+    fontFamily: root.fontFamily
+    fontSize: Style.font.caption
+    horizontalPadding: Style.space(10)
+    // The full value, unclipped, is still one hover away -- and the tooltip is
+    // drawn by the kit's own auto-detecting Text, so it is neutralized too.
+    tooltipText: Model.plainLabel(name + " filter (" + shortcut + "): " + value)
+    onClicked: root.toggleFilterGroup(group)
+  }
+
   // State
   // status: "checking" | "unauthenticated" | "locked" | "unlocked"
   property string status: "checking"
@@ -9543,7 +9579,11 @@ Panel {
             color: Style.selectedFillFor(root.fg, Color.accent)
             borderSpec: Border.controlSpec("normal", Color.accent, Color.accent)
 
-            Row {
+            // A RowLayout, so the label can be told to take whatever the glyph
+            // and the dismiss button leave rather than a hand-measured slice of
+            // the banner. The name in it is a window title, so its length is
+            // not ours to predict.
+            RowLayout {
               anchors.fill: parent
               anchors.leftMargin: Style.space(8)
               anchors.rightMargin: Style.space(6)
@@ -9551,7 +9591,7 @@ Panel {
 
               Text {
                 textFormat: Text.PlainText
-                anchors.verticalCenter: parent.verticalCenter
+                Layout.alignment: Qt.AlignVCenter
                 text: "󰌠"
                 color: Color.accent
                 font.family: root.fontFamily
@@ -9560,20 +9600,18 @@ Panel {
 
               Text {
                 textFormat: Text.PlainText
-                anchors.verticalCenter: parent.verticalCenter
+                Layout.alignment: Qt.AlignVCenter
+                Layout.fillWidth: true
                 text: "Suggested for " + (root.detectedContext ? root.detectedContext.displayName : "active window")
                 color: Color.accent
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.caption
                 font.bold: true
                 elide: Text.ElideRight
-                width: parent.width - Style.space(60)
               }
 
-              Item { Layout.fillWidth: true }
-
               PanelActionButton {
-                anchors.verticalCenter: parent.verticalCenter
+                Layout.alignment: Qt.AlignVCenter
                 iconText: "󰅖"
                 tooltipText: "Dismiss suggestion"
                 fontFamily: root.fontFamily
@@ -10032,34 +10070,55 @@ Panel {
           }
 
           // The three collapsed buttons. Identical shape, so none reads as a
-          // different kind of control from the others.
-          Row {
+          // different kind of control from the others -- which is why they are
+          // one component declared three times rather than three buttons.
+          //
+          // A Flow rather than a Row. Two of the three carry a vault name, so
+          // their width is whatever the user typed, and a Row can neither
+          // shrink a child nor start a second line -- it lays the overflow out
+          // past the panel edge, off both sides at once because the group is
+          // centred. `width` is the group's own combined width while the three
+          // share a line, which is what keeps it centred, and the panel's when
+          // they cannot. It reads the buttons' implicitWidth, never their
+          // width, so the layout's width never depends on its own result.
+          //
+          // This is what pays for the labels naming their filters: the three
+          // fit one line in the ordinary case and take a second when they do
+          // not, instead of the names having to be dropped to guarantee one.
+          Flow {
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: Style.space(6)
+            readonly property real naturalWidth: folderFilterButton.implicitWidth
+              + organizationFilterButton.implicitWidth
+              + typeFilterButton.implicitWidth
+              + spacing * 2
+            width: Math.min(parent.width, naturalWidth)
 
-            Repeater {
-              model: [
-                { group: "folders", icon: "󰉋", name: "Folders", value: root.folderFilterLabel() },
-                { group: "organizations", icon: "󰦑", name: "Organizations", value: root.organizationFilterLabel() },
-                { group: "types",   icon: "󰀻", name: "Types",   value: root.typeFilterLabel() }
-              ]
+            VaultFilterButton {
+              id: folderFilterButton
+              group: "folders"
+              glyph: "󰉋"
+              name: "Folders"
+              value: root.folderFilterLabel()
+              shortcut: "f"
+            }
 
-              delegate: Button {
-                required property var modelData
-                // The value half is a vault folder/organization name, and
-                // Ui.Button renders it with an auto-detecting Text.
-                text: Model.plainLabel(modelData.name + ": " + modelData.value)
-                iconText: root.openFilterGroup === modelData.group ? "󰅀" : modelData.icon
-                selected: root.openFilterGroup === modelData.group
-                accent: Color.accent
-                fontFamily: root.fontFamily
-                fontSize: Style.font.caption
-                horizontalPadding: Style.space(10)
-                tooltipText: modelData.name + " filter ("
-                  + (modelData.group === "folders" ? "f"
-                     : modelData.group === "organizations" ? "o" : "t") + ")"
-                onClicked: root.toggleFilterGroup(modelData.group)
-              }
+            VaultFilterButton {
+              id: organizationFilterButton
+              group: "organizations"
+              glyph: "󰦑"
+              name: "Organizations"
+              value: root.organizationFilterLabel()
+              shortcut: "o"
+            }
+
+            VaultFilterButton {
+              id: typeFilterButton
+              group: "types"
+              glyph: "󰀻"
+              name: "Types"
+              value: root.typeFilterLabel()
+              shortcut: "t"
             }
           }
 
@@ -10074,19 +10133,31 @@ Panel {
           spacing: Style.space(12)
 
           // Back Navigation & Action Header
-          Row {
+          //
+          // A Flow, not a Row, because how many buttons are here is decided at
+          // runtime: the suggestion button appears only on a recognised window,
+          // and it is the widest of the four. A Row cannot shrink a child or
+          // start a second line, so the fourth button was laid out past the
+          // panel's right edge and Delete simply left the panel -- worse still
+          // only once the suggestion was pinned, because "Suggested here" is a
+          // character wider than "Suggest here" and that character was the one
+          // that overflowed. The panel is also narrower than its 450 ask on a
+          // small screen (see fittedContentWidth), so no arrangement of fixed
+          // labels is safe; wrapping is. Everything still fits on one line at
+          // the default size, so this only shows itself when it has to.
+          Flow {
             width: parent.width
             spacing: Style.space(8)
 
             Button {
-              text: "Back to list (Esc)"
+              // "Back to list" spelled out cost more width than the row could
+              // spare, and the Sends screen already says just "Back (Esc)".
+              text: "Back (Esc)"
               iconText: "󰁍"
               fontFamily: root.fontFamily
               fontSize: Style.font.bodySmall
               onClicked: root.currentScreen = "main"
             }
-
-            Item { Layout.fillWidth: true }
 
             Button {
               visible: Boolean(root.detectedContext && root.detectedContext.displayName && root.detailItem && root.detailItem.typeCode !== 5)
@@ -10370,7 +10441,7 @@ Panel {
                 width: parent.width
                 spacing: Style.space(4)
 
-                Row {
+                RowLayout {
                   width: parent.width
                   PanelSectionHeader { text: "VERIFICATION CODE (TOTP)" }
                   Item { Layout.fillWidth: true }
@@ -10381,7 +10452,7 @@ Panel {
                     font.family: root.fontFamily
                     font.pixelSize: Style.font.caption
                     font.bold: true
-                    anchors.verticalCenter: parent.verticalCenter
+                    Layout.alignment: Qt.AlignVCenter
                   }
                 }
 
@@ -10494,7 +10565,7 @@ Panel {
                 width: parent.width
                 spacing: Style.space(4)
 
-                Row {
+                RowLayout {
                   width: parent.width
                   spacing: Style.space(6)
                   PanelSectionHeader { text: "ATTACHMENTS" }
@@ -10605,7 +10676,7 @@ Panel {
                 width: parent.width
                 spacing: Style.space(4)
 
-                Row {
+                RowLayout {
                   width: parent.width
                   PanelSectionHeader { text: "NOTES" }
                   Item { Layout.fillWidth: true }
@@ -10854,7 +10925,7 @@ Panel {
           width: parent.width
           spacing: Style.space(10)
 
-          Row {
+          RowLayout {
             width: parent.width
             spacing: Style.space(8)
 
@@ -10870,7 +10941,7 @@ Panel {
 
             Text {
               textFormat: Text.PlainText
-              anchors.verticalCenter: parent.verticalCenter
+              Layout.alignment: Qt.AlignVCenter
               text: root.formIsEditing ? "Edit Item" : "New Vault Item"
               color: root.fg
               font.family: root.fontFamily
@@ -11210,7 +11281,7 @@ Panel {
                 visible: root.formTypeCode === 1
                 width: parent.width
                 spacing: Style.space(3)
-                Row {
+                RowLayout {
                   width: parent.width
                   Text { textFormat: Text.PlainText; text: "PASSWORD"; color: root.dim; font.family: root.fontFamily; font.pixelSize: Style.font.caption; font.bold: true }
                   Item { Layout.fillWidth: true }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Your Bitwarden vault in the **Omarchy** status bar. Search, copy, and manage
 every item type without opening a browser.
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-1.7.0-green.svg)](manifest.json)
+[![Version](https://img.shields.io/badge/version-1.7.1-green.svg)](manifest.json)
 [![Platform: Omarchy](https://img.shields.io/badge/platform-Omarchy%20%2F%20Hyprland-7c3aed.svg)](https://omarchy.org/)
 [![Requires: Bitwarden CLI + jq](https://img.shields.io/badge/requires-bw%20CLI%20%2B%20jq-175ddc.svg)](https://bitwarden.com/help/cli/)
 

--- a/SshAgentSettings.qml
+++ b/SshAgentSettings.qml
@@ -152,7 +152,11 @@ Column {
     color: panel.fg
   }
 
-  Row {
+  // A Flow, because which of these four are showing is decided by the routing
+  // state: the idle pair and the confirming pair are each narrow enough, but
+  // nothing in a Row enforces that, and a Row answers a set that is too wide by
+  // laying the last button out past the panel edge rather than wrapping it.
+  Flow {
     width: parent.width
     spacing: Style.space(8)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -75,13 +75,26 @@ to result; after a three-second prewarm while the password screen was already
 open, it took 1,026 ms -- a 1,615 ms / 61.1% reduction. These figures are a
 same-machine comparison, not a universal latency promise.
 
-Two suites need Qt rather than Node -- which any machine running the plugin
-already has. One checks that Escape reaches the panel from inside a text
-field; the other checks how Qt itself decides to draw a string, which is what
-makes a vault value markup or text:
+Some suites need Qt rather than Node -- which any machine running the plugin
+already has. They cover the things only a real Qt can answer: that Escape
+reaches the panel from inside a text field, how Qt itself decides to draw a
+string (which is what makes a vault value markup or text), and how wide the
+kit's Button actually renders a given label in the shell's font.
+
+That last one, `tst_row_widths.qml`, reads the panel's own QML and measures
+every row of buttons against the width of the panel they sit in. It needs to
+read those files from inside QML, which Qt gates behind an env var:
 
 ```bash
-QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner -input tests/qml
+QML_XHR_ALLOW_FILE_READ=1 QT_QPA_PLATFORM=offscreen \
+  /usr/lib/qt6/bin/qmltestrunner -input tests/qml
 ```
+
+Note the **Qt6** binary. A bare `qmltestrunner` on Arch is the Qt5 one from
+`qt5-declarative`; it reports `Library import requires a version` and exits 1
+with no test output at all. If a run prints nothing whatsoever, that is why.
+
+`QT_ASSUME_STDERR_HAS_CONSOLE=1` is worth adding while debugging a QML test --
+without it `console.log()` from inside QML is silently dropped.
 
 ---

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "io.github.elevate08.qs-bitwarden-cli",
   "name": "Bitwarden",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": "David Spencer",
   "license": "MIT",
   "description": "Bitwarden password manager integration for the Omarchy status bar and quick access panel.",

--- a/tests/folders.test.js
+++ b/tests/folders.test.js
@@ -104,5 +104,26 @@ check("the folder writer receives its payload through the private environment bi
     && /id:\s*createFolderProc[\s\S]{0,100}environment:\s*root\.folderEnv\(\)/.test(panelSrc),
   "createFolderProc is not bound to folderEnv()")
 
+// --- the collapsed filter buttons ---
+// Each button names its own keyboard shortcut in its tooltip, and the key that
+// actually opens the drawer lives in runShortcut(). Two places, so they can
+// disagree -- and a tooltip promising a key that does nothing is worse than no
+// tooltip. Pin them to each other.
+const filterButtons = [...panelSrc.matchAll(
+  /VaultFilterButton\s*\{[\s\S]*?group:\s*"([a-z]+)"[\s\S]*?shortcut:\s*"([a-z])"/g)]
+  .map(m => ({ group: m[1], shortcut: m[2] }))
+check("all three vault filter buttons are declared",
+  filterButtons.length === 3, JSON.stringify(filterButtons))
+for (const { group, shortcut } of filterButtons) {
+  const dispatch = new RegExp(`case "${shortcut}":\\s*toggleFilterGroup\\("${group}"\\)`)
+  check(`the "${shortcut}" in the ${group} filter tooltip is the key that opens it`,
+    dispatch.test(panelSrc), `no runShortcut case pairing "${shortcut}" with "${group}"`)
+}
+// The label is the vault value alone now, so the group name survives only in
+// the tooltip -- which is the one place still telling you what you are looking at.
+check("each filter button still names its group somewhere the user can reach",
+  /tooltipText: Model\.plainLabel\(name \+ " filter \(" \+ shortcut \+ "\): " \+ value\)/.test(panelSrc),
+  "the filter tooltip no longer carries the group name and value")
+
 console.log(`${pass} passed, ${failures.length} failed`)
 if (failures.length) { console.error("\nFAILURES:\n  " + failures.join("\n  ")); process.exit(1) }

--- a/tests/qml/tst_row_widths.qml
+++ b/tests/qml/tst_row_widths.qml
@@ -1,0 +1,477 @@
+// A row of buttons must fit the panel it is drawn in.
+//
+// QtQuick's Row is a positioner, not a layout: it cannot shrink a child and it
+// cannot start a second line. Anything wider than the panel is simply laid out
+// past the right edge, and the control that lands there is gone -- not clipped
+// with a scrollbar, not wrapped, just off the panel with no way to reach it.
+//
+// That is how "Suggested here" cost the detail view its Delete button. The
+// header holds four buttons only when the active window matched a login, and
+// the pinned label is one character wider than the unpinned one -- so the row
+// fit at 441px until the moment you clicked, and 454.5px after. Nothing in the
+// panel said so; the button was just missing.
+//
+// So this measures. It reads the panel's own QML, finds every Row of buttons,
+// rebuilds each label with the real font, and adds up what the kit will make
+// of them. A Row that does not fit fails here instead of in a screenshot.
+//
+// Rows declared as Flow or RowLayout are reported but not failed: those two
+// CAN wrap or shrink, which is the fix this test exists to push people toward.
+//
+// Needs the QML sources readable from QML, which Qt gates behind an env var:
+//
+//   QML_XHR_ALLOW_FILE_READ=1 QT_QPA_PLATFORM=offscreen \
+//     /usr/lib/qt6/bin/qmltestrunner -input tests/qml
+//
+import QtQuick
+import QtTest
+
+TestCase {
+  id: tc
+  name: "RowWidths"
+  when: windowShown
+  width: 600; height: 200
+  visible: true
+
+  // ---------------------------------------------------------------- budgets
+  //
+  // Panel.qml draws into `fittedContentWidth(Style.space(450))`. Rows inside a
+  // Flickable lose `scrollGutter` (Style.space(10)) on top of that, and rather
+  // than track which rows are and are not inside one, every panel row is held
+  // to the narrower 440. The SSH prompt is its own card: Style.space(460) less
+  // panelPadding (18) and the card border (2) on each side.
+  //
+  // These are the sizes at the default [font] base-size of 12. A theme scales
+  // fonts and spacing by the same factor -- Style.space() multiplies by
+  // fontScale too -- so the ratio this test pins holds at any base size.
+  readonly property int panelBudget: 440
+  readonly property int popupBudget: 420
+
+  // ------------------------------------------------------- the kit's Button
+  //
+  // qs.Ui.Button cannot be instantiated here: it imports qs.Commons, which
+  // imports Quickshell, whose plugin only loads inside the quickshell runtime.
+  // So its geometry is restated, from Ui/Button.qml:
+  //
+  //   implicitWidth: row.implicitWidth + horizontalPadding * 2
+  //                  + _reservedBorderLeft + _reservedBorderRight
+  //
+  // where the inner row is `icon + Style.spacing.controlGap + label`, the
+  // padding is Style.spacing.controlPaddingX, and the reserved border is the
+  // widest any state can paint (1px a side at the default border width).
+  // `verify_button_geometry_is_still_the_kits` below fails if that changes.
+  readonly property int controlGap: 8
+  readonly property int controlPaddingX: 10
+  readonly property int reservedBorder: 2
+
+  // Style.font tokens at base-size 12: caption .833, body-small .917, body 1.0,
+  // and `icon` defaults to `title` (1.167).
+  readonly property var fontPx: ({
+    "Style.font.caption": 10,
+    "Style.font.bodySmall": 11,
+    "Style.font.body": 12
+  })
+  readonly property int iconPx: 14
+
+  TextMetrics { id: labelMetrics; font.family: "monospace" }
+  TextMetrics { id: iconMetrics; font.family: "monospace"; font.pixelSize: tc.iconPx }
+
+  function labelWidth(text, px) {
+    labelMetrics.font.pixelSize = px
+    labelMetrics.text = text
+    return labelMetrics.advanceWidth
+  }
+
+  // One monospace cell at the icon size, NOT the glyph itself.
+  //
+  // These icons are Nerd Font private-use codepoints, which exist on a desktop
+  // running the shell and not on a CI runner -- and a missing glyph measures as
+  // the fallback's notdef box, so measuring them directly would quietly change
+  // every total the moment this runs somewhere without the font. In a patched
+  // monospace font a Nerd glyph occupies exactly one cell, so an ordinary
+  // character at the same pixel size is the same width and is everywhere.
+  // (Locally both measure 8.390625.)
+  function iconWidth(glyph) {
+    if (!glyph) return 0
+    iconMetrics.text = "M"
+    return iconMetrics.advanceWidth
+  }
+
+  function buttonWidth(button) {
+    var icon = iconWidth(button.icon)
+    var label = button.label === "" ? 0 : labelWidth(button.label, button.fontSize)
+    var gap = (icon > 0 && label > 0) ? tc.controlGap : 0
+    return icon + gap + label + button.paddingX * 2 + tc.reservedBorder
+  }
+
+  // ------------------------------------------------------------ reading QML
+  function readFile(relativePath) {
+    var xhr = new XMLHttpRequest()
+    xhr.open("GET", Qt.resolvedUrl("../../" + relativePath), false)
+    xhr.send()
+    return xhr.responseText || ""
+  }
+
+  // Every string literal in a binding, longest first. A label is often a
+  // conditional -- `root.sendMode === "create" ? "Back to Sends" : "Back"` --
+  // and the widest branch is the one that has to fit.
+  function widestLiteral(binding) {
+    var found = binding.match(/"((?:[^"\\]|\\.)*)"/g)
+    if (!found) return null
+    var widest = ""
+    for (var i = 0; i < found.length; i++) {
+      var value = found[i].slice(1, -1).replace(/\\"/g, "\"")
+      if (value.length > widest.length) widest = value
+    }
+    return widest
+  }
+
+  function propertyIn(body, name) {
+    var m = body.match(new RegExp("^\\s*" + name + ":\\s*(.*)$", "m"))
+    return m ? m[1].trim() : null
+  }
+
+  // Direct children only. A nested Row -- the per-item action buttons inside a
+  // list delegate, say -- is found and measured as a row in its own right, and
+  // must not also be counted as part of its parent.
+  function directChildren(body, type) {
+    var out = []
+    var open = new RegExp("(?:^|\\n)(\\s*)(?:" + type + ")\\s*\\{")
+    var rest = body
+    var depth = 0
+    var lines = body.split("\n")
+    var i
+    for (i = 0; i < lines.length; i++) {
+      var line = lines[i]
+      var isChild = depth === 1 && new RegExp("^\\s*(?:" + type + ")\\s*\\{").test(line)
+      if (isChild) {
+        var childDepth = 0
+        var collected = []
+        for (var j = i; j < lines.length; j++) {
+          collected.push(lines[j])
+          childDepth += (lines[j].match(/\{/g) || []).length
+          childDepth -= (lines[j].match(/\}/g) || []).length
+          if (childDepth === 0 && j > i) break
+        }
+        out.push(collected.join("\n"))
+      }
+      depth += (line.match(/\{/g) || []).length
+      depth -= (line.match(/\}/g) || []).length
+    }
+    return out
+  }
+
+  // Every Row / Flow / RowLayout in a file, with the buttons directly in it.
+  function rowsIn(source, file) {
+    var lines = source.split("\n")
+    var rows = []
+    for (var i = 0; i < lines.length; i++) {
+      var opener = lines[i].match(/^(\s*)(Row|Flow|RowLayout)\s*\{\s*$/)
+      if (!opener) continue
+      var depth = 0
+      var block = []
+      for (var j = i; j < lines.length; j++) {
+        block.push(lines[j])
+        depth += (lines[j].match(/\{/g) || []).length
+        depth -= (lines[j].match(/\}/g) || []).length
+        if (depth === 0 && j > i) break
+      }
+      var body = block.join("\n")
+      var buttons = []
+      var declarations = directChildren(body, "Button|VaultFilterButton")
+      for (var k = 0; k < declarations.length; k++) {
+        var declaration = declarations[k]
+        var textBinding = propertyIn(declaration, "text")
+        var label = textBinding === null ? null : widestLiteral(textBinding)
+        // A label with no literal in it is vault text or a computed string.
+        // Its width is not ours to know, so it is reported, never measured.
+        if (label === null) { buttons.push(null); continue }
+        var sizeBinding = propertyIn(declaration, "fontSize")
+        var iconBinding = propertyIn(declaration, "iconText")
+        var padBinding = propertyIn(declaration, "horizontalPadding")
+        buttons.push({
+          label: label,
+          icon: iconBinding === null ? "" : (widestLiteral(iconBinding) || ""),
+          fontSize: (sizeBinding && tc.fontPx[sizeBinding] !== undefined)
+            ? tc.fontPx[sizeBinding] : tc.fontPx["Style.font.body"],
+          paddingX: padBinding === null ? tc.controlPaddingX : tc.controlPaddingX
+        })
+      }
+      var spacingBinding = propertyIn(body, "spacing")
+      var spacingMatch = spacingBinding ? spacingBinding.match(/Style\.space\((\d+)\)/) : null
+      rows.push({
+        file: file,
+        line: i + 1,
+        kind: opener[2],
+        spacing: spacingMatch ? parseInt(spacingMatch[1], 10) : 0,
+        buttons: buttons
+      })
+      i = j
+    }
+    return rows
+  }
+
+  function measure(row) {
+    var total = 0
+    for (var i = 0; i < row.buttons.length; i++) {
+      if (row.buttons[i] === null) return -1
+      total += buttonWidth(row.buttons[i])
+    }
+    return total + row.spacing * Math.max(0, row.buttons.length - 1)
+  }
+
+  // ------------------------------------------------------------------ tests
+  readonly property var sources: [
+    { file: "Panel.qml", budget: panelBudget },
+    { file: "SshAgentSettings.qml", budget: panelBudget },
+    { file: "SshApprovalScreen.qml", budget: popupBudget },
+    { file: "SshUnlockScreen.qml", budget: popupBudget }
+  ]
+
+  // Every budget here is a pixel count, and pixel counts only mean anything
+  // while the font puts every character in the same width of cell. If this
+  // machine resolves `monospace` to something proportional, the numbers below
+  // are measuring a different panel than the one that ships -- say so rather
+  // than report a pass or a failure that was never about the layout.
+  function test_the_font_is_monospaced() {
+    var narrow = labelWidth("iiiiiiiiii", 11)
+    var wide = labelWidth("MMMMMMMMMM", 11)
+    verify(narrow > 0 && Math.abs(narrow - wide) < 0.01,
+      "`monospace` resolved to a proportional font here (i=" + narrow
+      + ", M=" + wide + "), so these width budgets do not describe the panel")
+  }
+
+  function test_the_sources_are_readable() {
+    // Without QML_XHR_ALLOW_FILE_READ every parse silently finds nothing, and
+    // a test that measures nothing passes. Fail loudly instead.
+    for (var i = 0; i < sources.length; i++) {
+      var body = readFile(sources[i].file)
+      verify(body.length > 0,
+        sources[i].file + " read back empty -- set QML_XHR_ALLOW_FILE_READ=1")
+    }
+  }
+
+  function test_every_row_of_buttons_fits_its_panel() {
+    var offenders = []
+    var measured = 0
+    for (var i = 0; i < sources.length; i++) {
+      var rows = rowsIn(readFile(sources[i].file), sources[i].file)
+      for (var j = 0; j < rows.length; j++) {
+        var row = rows[j]
+        if (row.buttons.length < 2) continue
+        var total = measure(row)
+        if (total < 0) continue
+        measured++
+        // Flow wraps and RowLayout shrinks; neither can push a button off the
+        // panel, so neither is held to the single-line budget.
+        if (row.kind !== "Row") continue
+        if (total > sources[i].budget) {
+          offenders.push(row.file + ":" + row.line + " (" + row.buttons.length
+            + " buttons) needs " + total.toFixed(1)
+            + "px, panel gives " + sources[i].budget + "px")
+        }
+      }
+    }
+    verify(measured >= 12, "only measured " + measured + " rows -- the parser stopped seeing them")
+    // Every button is counted, including ones a `visible:` binding makes
+    // mutually exclusive -- the parser cannot evaluate those, and a row whose
+    // contents depend on runtime state is exactly the row that should wrap
+    // rather than be trusted to a hand-checked worst case. The remedy either
+    // way is one word: Flow.
+    verify(offenders.length === 0,
+      "these Rows lay a button out past the panel edge; make them a Flow, or "
+      + "shorten the labels:\n    " + offenders.join("\n    "))
+  }
+
+  // The header that started this. Pinned and unpinned are measured separately
+  // because only the pinned label overflowed, which is why it survived review.
+  function test_the_detail_header_fits_with_the_suggestion_button_showing() {
+    var header = { spacing: 8, buttons: [
+      { label: "Back (Esc)", icon: "\u{f040d}", fontSize: 11, paddingX: 10 },
+      { label: "Suggested here", icon: "\u{f043e}", fontSize: 11, paddingX: 10 },
+      { label: "Edit", icon: "\u{f03eb}", fontSize: 11, paddingX: 10 },
+      { label: "Delete", icon: "\u{f01b4}", fontSize: 11, paddingX: 10 }
+    ] }
+    var pinned = measure(header)
+    header.buttons[1].label = "Suggest here"
+    header.buttons[1].icon = "\u{f043d}"
+    var unpinned = measure(header)
+    verify(pinned <= panelBudget,
+      "pinned header needs " + pinned.toFixed(1) + "px of " + panelBudget)
+    verify(unpinned <= panelBudget,
+      "unpinned header needs " + unpinned.toFixed(1) + "px of " + panelBudget)
+  }
+
+  // The filter row names each filter as well as showing its value, because
+  // three chips reading "All" say nothing about which is which. That costs
+  // width, and the row is allowed to wrap to pay for it -- so what has to hold
+  // is not that every combination fits one line, but these two things.
+  function filterChip(name, value, glyph) {
+    // Model.clipLabel(value, 20), restated.
+    var clipped = value.length <= 20 ? value : value.slice(0, 17) + "..."
+    return { label: name + ": " + clipped, icon: glyph, fontSize: 10, paddingX: 10 }
+  }
+
+  // One: the state the panel actually opens in stays on a single line. If this
+  // fails the row wraps by default, which is a worse row than a shorter label.
+  function test_the_unfiltered_filter_row_is_one_line() {
+    var row = { spacing: 6, buttons: [
+      filterChip("Folders", "All", "\u{f024b}"),
+      filterChip("Organizations", "All", "\u{f0991}"),
+      filterChip("Types", "All", "\u{f003b}")
+    ] }
+    var total = measure(row)
+    verify(total <= panelBudget,
+      "the default filter row needs " + total.toFixed(1) + "px of " + panelBudget
+      + " -- it would open already wrapped")
+  }
+
+  // Two: no single chip can be wider than the panel, whatever is in the vault.
+  // A Flow can move a button to the next line but never make one narrower, so
+  // this is the one thing wrapping cannot rescue -- it is what the clip is for.
+  function test_no_filter_chip_can_outgrow_the_panel_on_its_own() {
+    var monstrous = "Acme Corporation Holdings International Limited"
+    var names = [["Folders", "\u{f024b}"], ["Organizations", "\u{f0991}"], ["Types", "\u{f003b}"]]
+    for (var i = 0; i < names.length; i++) {
+      var chip = filterChip(names[i][0], monstrous, names[i][1])
+      var width = buttonWidth(chip)
+      verify(width <= panelBudget,
+        names[i][0] + " chip reaches " + width.toFixed(1) + "px of " + panelBudget
+        + " with a long vault name -- the clip is not holding")
+    }
+  }
+
+  // --------------------------------------------------- the wrapping is real
+  //
+  // Everything above is arithmetic. This part instantiates the two containers
+  // the fix relies on and checks they behave, because both do something a Row
+  // does not: the header wraps, and the filter row shrink-wraps so it can stay
+  // centred while it fits and take the whole panel when it cannot.
+  //
+  // The chips stand in for qs.Ui.Button -- which will not load here -- using
+  // the same implicitWidth this file already restates.
+  Component {
+    id: chip
+    Item {
+      // Named, because inside a Component `parent` is the Flow it is created
+      // in, not this Item -- reaching the label through `parent` silently
+      // measures an empty string and nothing ever wraps.
+      id: chipRoot
+      property string label: ""
+      property int px: 11
+      implicitWidth: chipMetrics.advanceWidth + tc.controlGap + tc.iconWidth("\u{f01b4}")
+        + tc.controlPaddingX * 2 + tc.reservedBorder
+      width: implicitWidth
+      height: 26
+      TextMetrics {
+        id: chipMetrics
+        font.family: "monospace"
+        font.pixelSize: chipRoot.px
+        text: chipRoot.label
+      }
+    }
+  }
+
+  Item {
+    id: headerHost
+    width: tc.panelBudget
+    height: 100
+    Flow {
+      id: headerFlow
+      width: parent.width
+      spacing: 8
+    }
+  }
+
+  Item {
+    id: filterHost
+    width: tc.panelBudget
+    height: 100
+    Flow {
+      id: filterFlow
+      anchors.horizontalCenter: parent.horizontalCenter
+      spacing: 6
+      // The binding under test, copied from Panel.qml: it reads the chips'
+      // implicitWidth and never their width, so it cannot feed itself.
+      readonly property real naturalWidth: {
+        var total = 0
+        for (var i = 0; i < children.length; i++) total += children[i].implicitWidth
+        return total + spacing * Math.max(0, children.length - 1)
+      }
+      width: Math.min(parent.width, naturalWidth)
+    }
+  }
+
+  function fill(flow, labels, px) {
+    for (var i = flow.children.length - 1; i >= 0; i--) flow.children[i].destroy()
+    wait(20) // destroy() is deferred; the children are still there until it runs
+    for (var j = 0; j < labels.length; j++) {
+      chip.createObject(flow, { label: labels[j], px: px })
+    }
+    wait(20)
+    compare(flow.children.length, labels.length, "the stub chips did not all get created")
+    for (var k = 0; k < flow.children.length; k++) {
+      verify(flow.children[k].implicitWidth > 0,
+        "a stub chip measured as zero-width -- it is not measuring its label")
+    }
+  }
+
+  function overhang(flow, host) {
+    var worst = 0
+    for (var i = 0; i < flow.children.length; i++) {
+      var child = flow.children[i]
+      var edge = child.mapToItem(host, child.width, 0).x
+      if (edge - host.width > worst) worst = edge - host.width
+    }
+    return worst
+  }
+
+  function test_the_header_wraps_instead_of_pushing_a_button_off_the_panel() {
+    fill(headerFlow, ["Back (Esc)", "Suggested here", "Edit", "Delete"], 11)
+    var oneLine = headerFlow.height
+    compare(overhang(headerFlow, headerHost), 0, "a button hangs past the panel at full width")
+
+    // The narrow panel a small screen actually produces.
+    headerHost.width = 300
+    wait(20)
+    compare(overhang(headerFlow, headerHost), 0, "a button hangs past a 300px panel")
+    verify(headerFlow.height > oneLine, "the header should have taken a second line")
+
+    headerHost.width = tc.panelBudget
+    wait(20)
+    compare(headerFlow.height, oneLine, "and should return to one line")
+  }
+
+  function test_the_filter_row_stays_centred_while_it_fits_and_wraps_when_it_does_not() {
+    fill(filterFlow, ["Unfiled", "Personal", "Favorites"], 10)
+    verify(filterFlow.width < filterHost.width,
+      "the row should shrink-wrap so it can be centred, got " + filterFlow.width)
+    var left = filterFlow.x
+    var right = filterHost.width - (filterFlow.x + filterFlow.width)
+    verify(Math.abs(left - right) < 1.5, "not centred: left " + left + ", right " + right)
+
+    filterHost.width = 200
+    wait(20)
+    compare(filterFlow.width, 200, "the row should take the whole panel once it must wrap")
+    compare(overhang(filterFlow, filterHost), 0, "a filter chip hangs past the panel")
+
+    filterHost.width = tc.panelBudget
+    wait(20)
+    verify(filterFlow.width < tc.panelBudget, "the row should shrink-wrap and re-centre")
+  }
+
+  // The restated geometry above is only right while the kit's is unchanged.
+  function test_button_geometry_is_still_the_kits() {
+    var xhr = new XMLHttpRequest()
+    xhr.open("GET", "file:///usr/share/omarchy/shell/Ui/Button.qml", false)
+    xhr.send()
+    var source = xhr.responseText || ""
+    if (source.length === 0) return // kit not installed here; nothing to check
+    verify(source.indexOf(
+      "implicitWidth: row.implicitWidth + horizontalPadding * 2 "
+      + "+ _reservedBorderLeft + _reservedBorderRight") >= 0,
+      "Ui/Button.qml no longer sizes itself the way this test assumes")
+    verify(/spacing:\s*Style\.spacing\.controlGap/.test(source),
+      "Ui/Button.qml no longer gaps its icon and label by controlGap")
+  }
+}

--- a/tests/rich-text.test.js
+++ b/tests/rich-text.test.js
@@ -12,6 +12,7 @@ const Model = {}
 new Function("exports", fs.readFileSync(path.join(__dirname, "..", "BitwardenModel.js"), "utf8")
   .replace(/^\.pragma library\s*$/m, "") + `
   exports.plainLabel = plainLabel
+  exports.clipLabel = clipLabel
 `)(Model)
 
 let pass = 0
@@ -71,13 +72,53 @@ for (const file of ["Panel.qml", "SshAgentSettings.qml", "SshApprovalScreen.qml"
 const panel = ["Panel.qml", "SshAgentSettings.qml", "SshApprovalScreen.qml", "FormPickerRow.qml", "StatusNotice.qml", "DetailField.qml", "WheelScroll.qml"]
   .map(file => fs.readFileSync(path.join(__dirname, "..", file), "utf8"))
   .join("\n")
-for (const binding of ["formFolderLabel()", "formOrgLabel()", 'modelData.name + ": " + modelData.value']) {
+for (const binding of ["formFolderLabel()", "formOrgLabel()", "Model.clipLabel(value, 20)",
+                       'name + " filter (" + shortcut + "): " + value']) {
   const line = panel.split("\n").find(l => l.includes(binding) && /^\s*(text|tooltipText):/.test(l))
   check(`the button label built from ${binding} goes through plainLabel`,
     Boolean(line) && line.includes("Model.plainLabel("), String(line))
 }
+
+// Order matters, and only one order is safe. plainLabel may return a <span>
+// wrapper, so clipping its output could cut a tag in half and hand the control
+// the markup the wrapper exists to prevent. Clip the raw value, then neutralize.
+const clipLine = panel.split("\n").find(l => l.includes("Model.clipLabel("))
+check("the vault value is clipped before it is neutralized, never after",
+  Boolean(clipLine)
+    && clipLine.indexOf("Model.plainLabel(") >= 0
+    && clipLine.indexOf("Model.plainLabel(") < clipLine.indexOf("Model.clipLabel(")
+    && !/Model\.clipLabel\(\s*Model\.plainLabel\(/.test(clipLine),
+  String(clipLine))
 check("the suggestion tooltip neutralizes the window title it quotes",
   /tooltipText: Model\.plainLabel\(\(pinned/.test(panel), "expected Model.plainLabel around the tooltip")
+
+// --- clipping vault text to a width the panel can hold ---
+// Ui.Button has no elide, so a folder name decides how wide a button is. The
+// clip is what keeps that decision ours; the ellipsis lives inside the budget,
+// so `max` is a real ceiling and not a suggestion.
+check("a value already within the budget is returned untouched",
+  Model.clipLabel("Work", 20) === "Work", Model.clipLabel("Work", 20))
+check("a value exactly at the budget is not clipped",
+  Model.clipLabel("12345678901234567890", 20) === "12345678901234567890",
+  Model.clipLabel("12345678901234567890", 20))
+check("a longer value is cut to the budget, ellipsis included",
+  Model.clipLabel("123456789012345678901", 20) === "12345678901234567...",
+  Model.clipLabel("123456789012345678901", 20))
+for (const [value, max] of [["Client Projects 2026", 20], ["x".repeat(400), 20],
+                            ["short", 4], ["abc", 2], ["abcd", 3]]) {
+  check(`clipLabel(${JSON.stringify(value).slice(0, 24)}, ${max}) never exceeds its budget`,
+    Model.clipLabel(value, max).length <= max, Model.clipLabel(value, max))
+}
+check("a missing or unusable value clips to the empty string, never to \"null\"",
+  Model.clipLabel(null, 20) === "" && Model.clipLabel(undefined, 20) === "",
+  JSON.stringify([Model.clipLabel(null, 20), Model.clipLabel(undefined, 20)]))
+check("a nonsense budget still returns something drawable",
+  Model.clipLabel("Work", 0).length > 0 && Model.clipLabel("Work", -5).length > 0,
+  JSON.stringify([Model.clipLabel("Work", 0), Model.clipLabel("Work", -5)]))
+// The clip runs on raw vault text, so it must not be what introduces markup.
+check("clipping cannot manufacture markup that plainLabel then has to catch",
+  Model.plainLabel(Model.clipLabel("<img src=x onerror=alert(1)>", 20)).indexOf("<img") < 0,
+  Model.plainLabel(Model.clipLabel("<img src=x onerror=alert(1)>", 20)))
 
 console.log(`${pass} passed, ${failures.length} failed`)
 if (failures.length) { console.error("\nFAILURES:\n  " + failures.join("\n  ")); process.exit(1) }

--- a/tests/ssh-agent-artifact.test.js
+++ b/tests/ssh-agent-artifact.test.js
@@ -248,12 +248,25 @@ check("drift is still fatal on a same-repository run",
 // trigger still named the SSH agent's feature branch after that work reached
 // master, and a paths filter of agent/** kept the panel -- Panel.qml,
 // BitwardenModel.js, tests/ -- entirely outside the workflow. PR #13 merged
-// with `no checks reported`. Both halves are asserted, because fixing one
-// leaves the hole open.
-check("CI runs against master, where the code now lands",
-  /push:\s*\n\s*branches:\s*\[master[,\]]/.test(workflow)
-    && /pull_request:\s*\n\s*branches:\s*\[master[,\]]/.test(workflow),
-  "the workflow does not run on master pushes and master PRs")
+// with `no checks reported`.
+//
+// This used to require master on both triggers. It no longer does, and the
+// guarantee it was protecting has not been given up -- it moved. Work reaches
+// master only by merging a release branch, and master's protection requires
+// that branch to be up to date first, so the tree master ends up with is the
+// tree these gates already passed on the release branch at the commit they
+// passed on. Re-running on the master push would check the same tree twice.
+//
+// So what has to be true is that the release branches really are gated, which
+// the next check asserts, and that master is not silently left with nothing at
+// all -- it gets publish-on-master.yml, asserted below. Master being absent
+// from these triggers is deliberate and is pinned here so that reintroducing
+// it is a decision rather than a reflex.
+check("master is deliberately not gated here; the release branch it comes from is",
+  !/push:\s*\n\s*branches:\s*\[[^\]]*master/.test(workflow)
+    && !/pull_request:\s*\n\s*branches:\s*\[[^\]]*master/.test(workflow),
+  "master is back in these triggers -- if that is intended, this check and the "
+    + "trigger comment both need updating, because it means the same tree is checked twice")
 // A release is assembled on a release branch before it is tagged, so the same
 // gates have to cover it. Listing master alone let a PR into `release/1.7.0`
 // merge with `no checks reported` -- PR #13's hole reached through the base
@@ -262,6 +275,26 @@ check("CI runs against release branches too, where a release is assembled",
   /push:\s*\n\s*branches:\s*\[[^\]]*'release\/\*\*'/.test(workflow)
     && /pull_request:\s*\n\s*branches:\s*\[[^\]]*'release\/\*\*'/.test(workflow),
   "the workflow does not run on release-branch pushes and PRs into them")
+// Master is not unwatched, it just has exactly one job. A release is built,
+// verified and attested on its release branch and left as a draft; reaching
+// master is what publishes it. If that workflow ever starts building or
+// testing, the reason master was taken off the gates above stops holding.
+const publish = read(".github/workflows/publish-on-master.yml")
+check("something does run on a master push, and it is the publish",
+  /push:\s*\n\s*branches:\s*\[master\]/.test(publish),
+  "nothing runs on master at all now")
+check("the publish only publishes -- it does not build or test",
+  !/cargo (build|test|clippy)|npm |node |qmltestrunner|build-agent\.sh/.test(publish),
+  "the master workflow has grown work that belongs on the release branch")
+check("the publish is the only thing granted write access",
+  /permissions:\s*\n\s*contents:\s*write/.test(publish)
+    && /permissions:\s*\n\s*contents:\s*read/.test(workflow),
+  "write access is not where it was expected")
+// Publishing from the tag announced a version before master contained it.
+check("the tag build leaves the release as a draft for master to publish",
+  /gh release create "\$TAG"[^\n]*--draft/.test(read(".github/workflows/release.yml")),
+  "release.yml publishes at tag time again, so master's merge is no longer what releases")
+
 check("no paths filter decides which changes are checked",
   !/^\s*paths:/m.test(workflow),
   "a paths filter is how the panel went unchecked; these gates are cheap enough to always run")


### PR DESCRIPTION
Release **v1.7.1** — a bug-fix release, plus the CI change that came out of reviewing it.

`release/1.7.1` is a strict descendant of `master` (master ahead by 0), so this merges as a fast-forward and the tree master ends up with is byte-identical to the one CI verified on this branch.

## Fixed

- **A button could be laid out past the edge of the panel and vanish.** The detail header gained a fourth button (**Suggested here**) on a recognised window, and a QtQuick `Row` can neither shrink a child nor start a second line — so **Delete** was pushed off the panel. It only broke once the suggestion was *pinned*, because that label is one character wider. (#20)
- **The filter row had the same fault on worse odds** — its labels carry vault names of no fixed length and the row is centred, so it spilled off both edges. `Unfiled / Personal / Favorites` was already over.
- **The SSH client-routing row in Settings** could overflow the same way. Found by the new test, not by reading.
- **Seven dead spacers.** `Item { Layout.fillWidth: true }` inside plain `Row`s, which ignore Layout attached properties — the `18s` beside **VERIFICATION CODE (TOTP)**, and the controls beside **ATTACHMENTS**, **NOTES** and **PASSWORD**.

Guarded by `tests/qml/tst_row_widths.qml`, which reads the panel's own QML and fails any non-wrapping `Row` that exceeds the panel it is drawn in.

## CI

- **cargo-deny is downloaded, not compiled** (#21). It was 118s of compiling to produce a checker that ran in one. `gates` 214s → 102s; whole run ~250s → ~120s.
- **Two gate holes closed** (#20): the QML skip rule matched the shell's path anywhere in a file rather than on an `import` line, which would have silently skipped the new test on every runner while still reporting success; and the runner now sets `QML_XHR_ALLOW_FILE_READ`.

## Not included

Screenshots are stale — `02-login-detail.png` still shows `Back to list (Esc)` and the misaligned `18s`. Deliberately skipped; `demo/capture.sh` restarts the shell against a fixture vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
