### PR TITLE
ci: publish the release when it reaches master, and only then

### DIFF
--- a/.github/workflows/agent-build.yml
+++ b/.github/workflows/agent-build.yml
@@ -35,10 +35,24 @@ on:
   # only master's branch list covered would merge with `no checks
   # reported` -- the same hole reached through the base branch rather
   # than through a path.
+  #
+  # Master is deliberately NOT listed, and that is not the same mistake in
+  # reverse. Work reaches master only by merging a release branch, and master
+  # requires that branch to be up to date before it can -- so the tree master
+  # ends up with is the tree this workflow already passed on the release
+  # branch, at the commit it passed on. Running again on the push would check
+  # the same tree twice, and running on the pull request would check a merge
+  # preview of it that cannot differ. The one thing master does need is
+  # publication, which is publish-on-master.yml.
+  #
+  # The exposure this accepts, stated plainly: a pull request into master from
+  # something other than a release branch gets no checks. Nothing mechanically
+  # prevents one. It is the release branches that are gated, so that is the
+  # route work has to take.
   push:
-    branches: [master, 'release/**']
+    branches: ['release/**']
   pull_request:
-    branches: [master, 'release/**']
+    branches: ['release/**']
   workflow_dispatch:
   # Callable as a reusable workflow. release.yml is the only caller: it runs
   # every gate below against a release tag before anything is published.

--- a/.github/workflows/publish-on-master.yml
+++ b/.github/workflows/publish-on-master.yml
@@ -1,0 +1,119 @@
+# The one thing that happens when work reaches master.
+#
+# A release is built, verified, attested and assembled on its release branch,
+# where the tag is pushed -- see release.yml, which leaves the result as a
+# draft. Nothing is rebuilt here and nothing is re-verified: the commit master
+# now holds is the commit that was already checked, and checking it a second
+# time would only prove the runner is deterministic.
+#
+# What is missing at that point is publication. A tag on a release branch is a
+# candidate; the same commit on master is the release. This flips the draft,
+# and does nothing else.
+#
+# It follows that master carries no other workflow. agent-build.yml runs on
+# release branches and on pull requests into them, not here.
+
+name: publish on master
+
+on:
+  push:
+    branches: [master]
+  # Publishing is idempotent -- an already-published release is left alone --
+  # so a run can be repeated by hand if a push happened while this was broken.
+  workflow_dispatch:
+
+# The only write this repository's CI does, and it writes releases rather than
+# code: no branch, no tag and no tracked file is touched from here.
+permissions:
+  contents: write
+
+concurrency:
+  # Two merges in quick succession must not race to publish the same draft.
+  # Never cancelled: a half-published release is worse than a queued one.
+  group: publish-on-master
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: take the release out of draft
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out master
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags. The tag this is looking for is reachable
+          # from the merge, not pointing at it, and a shallow clone cannot see
+          # far enough back to find it.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Publish the release this merge brought in
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          # Which tagged commits did THIS push put on master? Answered by
+          # comparing what is reachable now with what was reachable before it,
+          # rather than by asking which tag is nearest.
+          #
+          # `git describe` was the obvious way and it is wrong here. Merging a
+          # release branch makes the tag a parent of master's new tip rather
+          # than the tip itself, and describe resolves the resulting tie by
+          # first-parent depth -- so on a merge commit it walks back into the
+          # base and reports the PREVIOUS release. It picked v1.0.0 over v1.7.1
+          # in exactly this shape. `git tag --points-at HEAD` fails the other
+          # way: it finds nothing at all unless the merge fast-forwarded.
+          #
+          # A reachability difference has neither failure. It is exact on a
+          # merge commit and on a fast-forward alike, and it publishes nothing
+          # that was already on master.
+          git tag --merged HEAD --list 'v*' | sort > /tmp/tags-now
+
+          if [ -n "${BEFORE:-}" ] && [ "$BEFORE" != "0000000000000000000000000000000000000000" ] \
+             && git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            git tag --merged "$BEFORE" --list 'v*' | sort > /tmp/tags-before
+          else
+            # First push to the branch, a force-push, or a dispatch run: there
+            # is no previous state to difference against. Fall back to every
+            # reachable tag and let the draft check below decide -- anything
+            # already published is left alone, so the worst case is a no-op.
+            echo "::notice::no usable before-state; considering every reachable tag"
+            : > /tmp/tags-before
+          fi
+
+          arrived="$(comm -23 /tmp/tags-now /tmp/tags-before)"
+          if [ -z "$arrived" ]; then
+            echo "::notice::this push brought no new v* tag onto master; nothing to publish"
+            exit 0
+          fi
+          echo "tags newly on master: $(echo $arrived)"
+
+          published=0
+          for tag in $arrived; do
+            if ! gh release view "$tag" >/dev/null 2>&1; then
+              # A tag can reach master with no release behind it -- an old one
+              # from before this workflow existed, or one pushed by hand. Not
+              # an error, and emphatically not something to invent a release
+              # for: the assets and the attestation are made on the release
+              # branch by release.yml, or not at all.
+              echo "::notice::no release exists for $tag; skipping"
+              continue
+            fi
+            if [ "$(gh release view "$tag" --json isDraft --jq .isDraft)" != "true" ]; then
+              echo "::notice::release $tag is already published; skipping"
+              continue
+            fi
+            # A release is a claim about what the default branch contains.
+            # Belt and braces on top of the reachability difference above.
+            if ! git merge-base --is-ancestor "$tag^{commit}" HEAD; then
+              echo "::error::$tag is not an ancestor of master; refusing to publish"
+              exit 1
+            fi
+            gh release edit "$tag" --draft=false
+            gh release view "$tag" --json isDraft,url --jq '"published \(.url) (isDraft=\(.isDraft))"'
+            published=$((published + 1))
+          done
+          echo "::notice::published $published release(s)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,10 +340,18 @@ jobs:
                   bin/x86_64-linux/qs-bitwarden-ssh-agent)
           prerelease=()
           case "$TAG" in *-*) prerelease=(--prerelease) ;; esac
+          # Created as a draft. A tag is pushed on a release branch, before
+          # that work has reached master, and a published release at that
+          # moment would be announcing a version the default branch does not
+          # yet contain. publish-on-master.yml takes the draft public when the
+          # tagged commit lands on master, which is the moment the release is
+          # real. Everything that costs anything -- the gates, the reports, the
+          # attestation, the assets -- has already happened here, on the
+          # release branch, where it belongs.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "::notice::release $TAG exists; uploading assets to it"
             gh release upload "$TAG" "${assets[@]}" --clobber
           else
-            gh release create "$TAG" "${assets[@]}" \
+            gh release create "$TAG" "${assets[@]}" --draft \
               --title "$TAG" --notes-file "$notes" "${prerelease[@]}"
           fi

--- a/tests/ssh-agent-artifact.test.js
+++ b/tests/ssh-agent-artifact.test.js
@@ -248,12 +248,25 @@ check("drift is still fatal on a same-repository run",
 // trigger still named the SSH agent's feature branch after that work reached
 // master, and a paths filter of agent/** kept the panel -- Panel.qml,
 // BitwardenModel.js, tests/ -- entirely outside the workflow. PR #13 merged
-// with `no checks reported`. Both halves are asserted, because fixing one
-// leaves the hole open.
-check("CI runs against master, where the code now lands",
-  /push:\s*\n\s*branches:\s*\[master[,\]]/.test(workflow)
-    && /pull_request:\s*\n\s*branches:\s*\[master[,\]]/.test(workflow),
-  "the workflow does not run on master pushes and master PRs")
+// with `no checks reported`.
+//
+// This used to require master on both triggers. It no longer does, and the
+// guarantee it was protecting has not been given up -- it moved. Work reaches
+// master only by merging a release branch, and master's protection requires
+// that branch to be up to date first, so the tree master ends up with is the
+// tree these gates already passed on the release branch at the commit they
+// passed on. Re-running on the master push would check the same tree twice.
+//
+// So what has to be true is that the release branches really are gated, which
+// the next check asserts, and that master is not silently left with nothing at
+// all -- it gets publish-on-master.yml, asserted below. Master being absent
+// from these triggers is deliberate and is pinned here so that reintroducing
+// it is a decision rather than a reflex.
+check("master is deliberately not gated here; the release branch it comes from is",
+  !/push:\s*\n\s*branches:\s*\[[^\]]*master/.test(workflow)
+    && !/pull_request:\s*\n\s*branches:\s*\[[^\]]*master/.test(workflow),
+  "master is back in these triggers -- if that is intended, this check and the "
+    + "trigger comment both need updating, because it means the same tree is checked twice")
 // A release is assembled on a release branch before it is tagged, so the same
 // gates have to cover it. Listing master alone let a PR into `release/1.7.0`
 // merge with `no checks reported` -- PR #13's hole reached through the base
@@ -262,6 +275,26 @@ check("CI runs against release branches too, where a release is assembled",
   /push:\s*\n\s*branches:\s*\[[^\]]*'release\/\*\*'/.test(workflow)
     && /pull_request:\s*\n\s*branches:\s*\[[^\]]*'release\/\*\*'/.test(workflow),
   "the workflow does not run on release-branch pushes and PRs into them")
+// Master is not unwatched, it just has exactly one job. A release is built,
+// verified and attested on its release branch and left as a draft; reaching
+// master is what publishes it. If that workflow ever starts building or
+// testing, the reason master was taken off the gates above stops holding.
+const publish = read(".github/workflows/publish-on-master.yml")
+check("something does run on a master push, and it is the publish",
+  /push:\s*\n\s*branches:\s*\[master\]/.test(publish),
+  "nothing runs on master at all now")
+check("the publish only publishes -- it does not build or test",
+  !/cargo (build|test|clippy)|npm |node |qmltestrunner|build-agent\.sh/.test(publish),
+  "the master workflow has grown work that belongs on the release branch")
+check("the publish is the only thing granted write access",
+  /permissions:\s*\n\s*contents:\s*write/.test(publish)
+    && /permissions:\s*\n\s*contents:\s*read/.test(workflow),
+  "write access is not where it was expected")
+// Publishing from the tag announced a version before master contained it.
+check("the tag build leaves the release as a draft for master to publish",
+  /gh release create "\$TAG"[^\n]*--draft/.test(read(".github/workflows/release.yml")),
+  "release.yml publishes at tag time again, so master's merge is no longer what releases")
+
 check("no paths filter decides which changes are checked",
   !/^\s*paths:/m.test(workflow),
   "a paths filter is how the panel went unchecked; these gates are cheap enough to always run")


### PR DESCRIPTION
Makes the release appear when the work reaches `master`, and makes that the only thing master does.

## The problem

`release.yml` triggers on `push: tags: v*`. Tags are pushed on release branches, so the GitHub Release was published *before* the commit reached the default branch — announcing a version master did not yet contain.

## The change

| | before | after |
|---|---|---|
| tag push on a release branch | gates, verify, attest, **publish** | gates, verify, attest, **draft** |
| push to `master` | full `agent build` | **publish the draft, nothing else** |
| PR into `master` | full `agent build` | nothing |
| push / PR on `release/**` | full `agent build` | unchanged |

Everything that costs anything still happens on the release branch. `publish-on-master.yml` only flips the draft — it checks out, reads tags, and calls `gh release edit`. Nothing is rebuilt or re-verified, because master's tree is the tree already checked on the release branch, at the commit it was checked on: master requires the branch to be up to date before merging, so the merge cannot introduce a tree CI has not seen.

## The trap in finding the tag

Worth reading, because the obvious approaches are both wrong.

Merging a release branch makes the tag a **parent** of master's new tip rather than the tip itself:

- `git tag --points-at HEAD` → empty, unless the merge fast-forwarded.
- `git describe --tags --abbrev=0` → resolves the tie by first-parent depth and walks back into the base. In a real merge topology with `v1.0.0` on master and `v1.7.1` on the merged branch, it returns **`v1.0.0`** — it would have published the *previous* release.

I had shipped `describe` in the first draft of this and caught it by building the topology rather than reasoning about it.

The workflow instead differences tag reachability against the push's before-state — "which tagged commits did this push put on master?" Exact on both topologies. Tested:

| case | result |
|---|---|
| merge commit, before = previous master | `v1.7.1` |
| fast-forward, before = previous master | `v1.7.1` |
| same push re-run (idempotency) | nothing to publish |
| branch-creation sentinel (all zeros) | falls back to all reachable; drafts decide |
| unknown / GC'd before-sha | same fallback |
| `workflow_dispatch` (empty before) | same fallback |

Publishing is idempotent regardless: an already-published release is skipped, and a tag with no release behind it is skipped rather than having one invented for it.

## Accepted exposure

A PR into `master` from something that is not a release branch now gets no checks, and nothing mechanically prevents one — GitHub has no way to restrict which branches may open a PR into a given base. Discipline, deliberately: the release branches are the gated route, so that is the route work takes. It is stated in the trigger comment rather than left to be discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
