### PR TITLE
feat: colorize and align the menu-bar icon

### DIFF
--- a/BitwardenModel.js
+++ b/BitwardenModel.js
@@ -5441,6 +5441,8 @@ var SETTINGS_SCHEMA = [
 
   { key: "closeOnCopy", group: "general", type: "bool", label: "Close panel on copy", defaultValue: true,
     description: "Return focus to your app as soon as Enter copies a credential." },
+  { key: "colorizeIcon", group: "general", type: "bool", label: "Colorize menu-bar icon", defaultValue: false,
+    description: "Use the active Omarchy theme accent for the primary menu-bar icon." },
   { key: "autoCopyTotpSec", group: "general", type: "int", label: "Auto-copy TOTP after", unit: "seconds",
     min: 0, max: 30, step: 1, zeroLabel: "Off", defaultValue: 3,
     description: "Replace the clipboard with the 2FA code this long after the password." },

--- a/Panel.qml
+++ b/Panel.qml
@@ -28,6 +28,7 @@ Panel {
   readonly property bool rememberSession: Model.boolSetting("rememberSession", setting("rememberSession", true))
   readonly property int autoCopyTotpSec: Model.intSetting("autoCopyTotpSec", setting("autoCopyTotpSec"))
   readonly property bool closeOnCopy: Model.boolSetting("closeOnCopy", setting("closeOnCopy", true))
+  readonly property bool colorizeIcon: Model.boolSetting("colorizeIcon", setting("colorizeIcon", false))
   readonly property bool suggestOnOpen: Model.boolSetting("suggestOnOpen", setting("suggestOnOpen", true))
   readonly property bool fingerprintUnlock: Model.boolSetting("fingerprintUnlock", setting("fingerprintUnlock", false))
   readonly property bool pinUnlock: Model.boolSetting("pinUnlock", setting("pinUnlock", false))
@@ -6517,16 +6518,12 @@ Panel {
       anchors.fill: parent
 
       // Constant Base Shield
-      Text {
-        textFormat: Text.PlainText
-        anchors.centerIn: parent
+      OpticalGlyph {
+        anchors.fill: parent
         text: "󰞀"
-        font.family: root.fontFamily
-        font.pixelSize: Style.bar.iconFont
-        color: bar ? bar.barForeground : Color.foreground
-        renderType: Text.NativeRendering
-        horizontalAlignment: Text.AlignHCenter
-        verticalAlignment: Text.AlignVCenter
+        fontFamily: root.fontFamily
+        fontSize: Style.bar.iconFont
+        color: root.colorizeIcon ? Color.accent : (bar ? bar.barForeground : Color.foreground)
       }
 
       // Mini Install Badge in the same corner while a required tool is absent.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ their own **DANGER ZONE** heading.
 Changes are written to the plugin's entry in `~/.config/omarchy/shell.json`
 through `omarchy bar set`, so Omarchy owns the file and the shell hot-reloads.
 
+The General settings include **Colorize menu-bar icon**, which makes the
+primary Bitwarden shield follow the active Omarchy theme accent. It is off by
+default; lock and setup/error indicators keep their existing status colors.
+
 <br clear="all">
 
 ---

--- a/docs/ideas/colorized-menu-bar-icon.md
+++ b/docs/ideas/colorized-menu-bar-icon.md
@@ -1,0 +1,66 @@
+# Colorized Menu-Bar Icon
+
+Status: refined design proposal, implementation approved
+
+## Problem Statement
+
+How might we let users who run a colorized desktop theme make the Bitwarden
+menu-bar icon feel native to that theme without introducing arbitrary color
+configuration or weakening the icon's status indicators?
+
+## Recommended Direction
+
+Add a single **Colorize menu-bar icon** toggle to the existing General settings
+screen. The setting is off by default, preserving the current appearance. When
+enabled, the primary shield glyph uses Omarchy's live `Color.accent` value;
+the preference stores only the boolean choice, so changing the desktop theme
+automatically changes the icon color.
+
+Only the primary shield is colorized. The locked-state padlock, missing-tool
+badge, and error/setup indicators retain their existing foreground and urgent
+colors. This keeps the accent color as personalization while preserving the
+meaning of exceptional states.
+
+The feature fits the existing settings path: schema and manifest metadata,
+`omarchy bar set` persistence, live shell reload, and the current settings-row
+keyboard interaction. No custom RGB picker or new dependency is needed.
+
+## Key Assumptions to Validate
+
+- [ ] Users want the active theme accent specifically, rather than an
+  independently chosen RGB value — validate with the first implementation and
+  feedback from users who requested colorization.
+- [ ] Keeping urgent/error badges independent is sufficient to preserve state
+  recognition — verify visually in locked, setup-required, and error states.
+- [ ] A boolean toggle is discoverable enough in the existing General section
+  — confirm the label and description are clear in the settings screenshot or
+  runtime review.
+
+## MVP Scope
+
+- Add `colorizeIcon` as a boolean setting, defaulting to `false`.
+- Add a General settings row labeled **Colorize menu-bar icon** with a
+  description explaining that it follows the active theme accent.
+- Bind the primary menu-bar shield color to `Color.accent` when enabled and to
+  the existing bar foreground when disabled.
+- Leave status badges and urgent/error colors unchanged.
+- Add model, manifest, persistence, malformed-value, and QML wiring tests.
+- Verify that theme changes are reflected after the shell reloads the panel.
+
+## Not Doing (and Why)
+
+- Arbitrary color picker or hex input — conflicts with the theme-derived goal
+  and adds validation and contrast problems.
+- Multiple palette choices — the accent is the one semantic theme color users
+  are most likely asking for; broader palettes can follow if demand appears.
+- Per-state color customization — risks making locked and error states harder
+  to recognize.
+- Changing the panel's internal icon, controls, or status badges — the request
+  is specifically about the menu-bar icon's primary glyph.
+
+## Open Questions
+
+- Should the setting be called **Colorize menu-bar icon** or **Use theme accent
+  for icon**? The former is more approachable; the latter is more explicit.
+- Does the active accent maintain adequate contrast across the supported Omarchy
+  themes, especially in light themes?

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,7 @@
       "rememberSession": true,
       "autoCopyTotpSec": 3,
       "closeOnCopy": true,
+      "colorizeIcon": false,
       "suggestOnOpen": true,
       "fingerprintUnlock": false,
       "pinUnlock": false,
@@ -92,6 +93,13 @@
         "label": "Close panel on Enter copy",
         "description": "Automatically close panel after selecting an item with Enter",
         "defaultValue": true
+      },
+      {
+        "key": "colorizeIcon",
+        "type": "boolean",
+        "label": "Colorize menu-bar icon",
+        "description": "Use the active Omarchy theme accent for the primary menu-bar icon.",
+        "defaultValue": false
       },
       {
         "key": "suggestOnOpen",

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -316,3 +316,206 @@ setting contract
 | The invisible experience leaves a password or pending process behind | Dismissal denies the request and runs popup-specific credential/prewarm cleanup. |
 | A request label injects markup | Every request-derived `Text` remains `Text.PlainText`. |
 | Overlay traps input after the request ends | Visibility and Wayland keyboard focus bind directly to the live pending request. |
+
+---
+
+# Implementation Plan: Colorized Menu-Bar Icon
+
+## Overview
+
+Add an opt-in `colorizeIcon` boolean setting to the Bitwarden panel. When
+enabled, the primary menu-bar shield follows Omarchy's live `Color.accent`
+theme color; when disabled, it keeps the current bar foreground color. The
+locked padlock, missing-dependency badge, and urgent/error indicators remain
+unchanged so color personalization does not erase status meaning.
+
+The existing settings renderer already turns boolean schema entries into
+keyboard-operable toggle rows. No custom color picker, palette model, new
+dependency, or arbitrary color persistence is required.
+
+## Architecture Decisions
+
+- Store only `colorizeIcon: boolean`; derive the actual color from
+  `Color.accent` at render time so theme changes are inherited automatically.
+- Default the setting to `false` so existing installations retain their current
+  appearance.
+- Apply the setting only to the primary shield glyph in `shieldIconComp`.
+  Leave the padlock and setup/error badges on their existing bindings.
+- Put the row in the General settings group, using the existing schema-driven
+  toggle and `omarchy bar set` persistence path.
+- Treat malformed external values as `false`, using the existing strict
+  boolean-setting behavior.
+
+## Dependency Graph
+
+```text
+manifest default/schema + model schema
+              │
+              ├── settings persistence/value lookup tests
+              │
+              └── Panel color binding + schema-driven General toggle
+                              │
+                              └── QML/static checks + runtime/theme verification
+```
+
+## Task List
+
+### Phase 1: Settings Contract
+
+- [x] Task 1: Add the colorization setting contract
+
+### Checkpoint: Settings Contract
+
+- [x] `colorizeIcon` exists in both `manifest.json` and `BitwardenModel.js`
+      with boolean type and a `false` default.
+- [x] Valid booleans round-trip through the existing writer, while malformed
+      values resolve to `false`.
+- [x] Focused settings/model tests pass before UI wiring begins.
+
+### Phase 2: Vertical UI Slice
+
+- [x] Task 2: Wire the theme-accent shield and General toggle
+
+### Checkpoint: Colorized Icon Behavior
+
+- [x] With the setting off, the primary shield still uses the bar foreground.
+- [x] With the setting on, the primary shield uses `Color.accent`.
+- [x] Lock/setup/error badges retain their existing foreground or urgent colors.
+- [x] The settings row is keyboard-operable and persists through the existing
+      shell reload path.
+
+### Phase 3: Verification and Documentation
+
+- [~] Task 3: Add regression coverage and document the setting
+
+### Checkpoint: Complete
+
+- [x] Focused and full JavaScript tests pass.
+- [x] QML tests/lint and plugin validation pass where the Omarchy environment is
+      available.
+- [ ] Manual verification covers both toggle states, a theme accent change,
+      locked state, setup-required state, and an error/urgent state.
+- [x] README or user-facing feature documentation explains the toggle and its
+      theme-derived behavior.
+- [ ] Human review approves the implementation before merge; no commit or push
+      is performed automatically.
+
+## Task Details
+
+### Task 1: Add the colorization setting contract
+
+**Description:** Register `colorizeIcon` as a General boolean setting in the
+manifest and model schema, expose its default through the widget defaults, and
+ensure the existing settings value/read/write paths recognize it without
+special-case persistence code.
+
+**Acceptance criteria:**
+
+- [x] The manifest and model declare the same `colorizeIcon` key, boolean type,
+      label, description, and `false` default.
+- [x] `boolSetting("colorizeIcon", true)` returns true; malformed values such
+      as strings and numbers fall back to false.
+- [x] The setting is grouped under General and included in visible settings
+      without changing existing group ordering or setting semantics.
+
+**Verification:**
+
+- [x] Tests pass: `node tests/setup-settings.test.js`
+- [x] Tests pass: `node tests/lock-state.test.js`
+- [x] Static check confirms manifest/model schema parity.
+
+**Dependencies:** None
+
+**Files likely touched:**
+
+- `manifest.json`
+- `BitwardenModel.js`
+- `tests/setup-settings.test.js`
+- `tests/lock-state.test.js`
+
+**Estimated scope:** Medium: 3–4 files
+
+### Task 2: Wire the theme-accent shield and General toggle
+
+**Description:** Add the root property that reads `colorizeIcon`, use it only
+for the primary shield glyph in the menu-bar icon component, and rely on the
+existing schema-driven settings delegate to render and persist the toggle.
+Add focused static assertions for the binding and for the unchanged status
+badge color paths.
+
+**Acceptance criteria:**
+
+- [x] `colorizeIcon` is read from the live setting with a false-safe default.
+- [x] The primary shield resolves to `Color.accent` when enabled and the
+      existing bar foreground when disabled.
+- [x] The padlock, missing-tool badge, and urgent/error color bindings are not
+      redirected through the new preference.
+
+**Verification:**
+
+- [x] Tests pass: `node tests/settings-screen.test.js`
+- [x] Focused source assertions pass for shield color precedence and badge
+      independence.
+- [x] QML lint passes for `Panel.qml` with the repository's Omarchy import path.
+
+**Dependencies:** Task 1
+
+**Files likely touched:**
+
+- `Panel.qml`
+- `tests/settings-screen.test.js`
+
+**Estimated scope:** Small: 1–2 files
+
+### Task 3: Add regression coverage and document the setting
+
+**Description:** Complete the feature's regression matrix and user-facing
+documentation. Verify that persistence survives the shell reload path and that
+the selected accent is inherited from the active theme while status indicators
+remain recognizable.
+
+**Acceptance criteria:**
+
+- [x] Tests cover default-off behavior, enabling/disabling through the settings
+      path, malformed persisted values, and preservation of badge colors.
+- [x] User-facing documentation says the toggle follows the active Omarchy
+      theme accent and does not offer arbitrary color selection.
+- [x] No unrelated panel colors or status semantics change.
+
+**Verification:**
+
+- [x] Full JavaScript suite passes:
+      `for test_file in tests/*.test.js; do node "$test_file" || exit 1; done`
+- [x] QML suite passes:
+      `env -u DISPLAY -u WAYLAND_DISPLAY -u QT_QPA_PLATFORMTHEME QML_XHR_ALLOW_FILE_READ=1 QT_QPA_PLATFORM=offscreen /usr/lib/qt6/bin/qmltestrunner -input tests/qml`
+- [x] Plugin validation passes: `omarchy plugin validate .`
+- [ ] Manual runtime check confirms both toggle states and theme-derived color
+      behavior when the desktop environment is available.
+
+**Dependencies:** Task 2
+
+**Files likely touched:**
+
+- `README.md` or the relevant feature documentation
+- `tests/setup-settings.test.js`
+- `tests/settings-screen.test.js`
+- `tests/lock-state.test.js`
+
+**Estimated scope:** Medium: 3–4 files
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Accent color has poor contrast on a supported theme | Medium | Check light/dark themes manually; retain the existing bar foreground as the safe default and do not alter urgent badges. |
+| The setting is added to one schema but not the other | Medium | Keep manifest/model parity assertions in the focused settings tests. |
+| The setting accidentally recolors status badges | High | Limit the binding change to the primary shield `Text` and assert badge bindings remain independent. |
+| Shell reload does not refresh the bar icon immediately | Low | Verify the existing `omarchy bar set` hot-reload behavior; do not add a second persistence mechanism. |
+
+## Open Questions
+
+- Confirm final user-facing label: **Colorize menu-bar icon** versus **Use
+  theme accent for icon**. The plan assumes the former.
+- Confirm which user-facing documentation file should receive the short setting
+  note; `README.md` is the default unless project conventions prefer
+  `docs/features.md`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1036,3 +1036,56 @@ available.
 - [x] No private key, password, session token, payload, or signature is added
       to persistent QML state, logs, argv, files, or tests.
 - [x] Human review approves merge; no commit or push is performed automatically.
+
+---
+
+# Task List: Colorized Menu-Bar Icon
+
+Source design: `docs/ideas/colorized-menu-bar-icon.md`.
+Implementation plan: `tasks/plan.md`, “Colorized Menu-Bar Icon”.
+
+## Task 1: Add the colorization setting contract
+
+- [x] Add `colorizeIcon` to the manifest defaults/schema and the model settings
+      schema as a General boolean with a false default.
+- [x] Extend focused settings tests for schema parity and strict false fallback
+      on malformed values.
+- [x] Verify with `node tests/setup-settings.test.js` and
+      `node tests/lock-state.test.js`.
+
+**Dependencies:** None
+
+## Task 2: Wire the theme-accent shield and General toggle
+
+- [x] Read `colorizeIcon` from the live setting in `Panel.qml`.
+- [x] Use `Color.accent` only for the primary shield when enabled; preserve the
+      existing foreground/urgent badge bindings.
+- [x] Add focused settings-screen/source assertions and run QML lint.
+
+**Dependencies:** Task 1
+
+## Checkpoint: Colorized Icon Behavior
+
+- [x] Off state matches the current bar icon.
+- [x] On state uses the active theme accent.
+- [x] Locked, setup-required, and error states retain their status indicators.
+- [ ] Human review confirms the UI label and behavior before final verification.
+
+## Task 3: Add regression coverage and document the setting
+
+- [x] Complete the focused and full regression coverage.
+- [x] Document the General toggle and theme-derived behavior in the chosen
+      user-facing documentation file.
+- [x] Run the full JavaScript/QML suites and `omarchy plugin validate .`.
+- [ ] Perform the manual runtime/theme verification when the desktop
+      environment is available.
+
+**Dependencies:** Task 2
+
+## Checkpoint: Colorized Menu-Bar Icon Complete
+
+- [x] All acceptance criteria in `docs/ideas/colorized-menu-bar-icon.md` and
+      `tasks/plan.md` pass.
+- [x] No unrelated icon, badge, or panel colors changed.
+- [ ] Human review approves the implementation; no commit or push is performed
+      automatically.

--- a/tests/settings-screen.test.js
+++ b/tests/settings-screen.test.js
@@ -21,6 +21,30 @@ const flickAt = panelSrc.indexOf("id: settingsFlick")
 const colAt = panelSrc.indexOf("id: settingsCol")
 const screen = screenAt < 0 ? "" : panelSrc.slice(screenAt, panelSrc.indexOf("SCREEN 1", screenAt))
 
+const shieldAt = panelSrc.indexOf("id: shieldIconComp")
+const statusBarAt = panelSrc.indexOf("// Status Bar Button", shieldAt)
+const shield = shieldAt < 0 ? "" : panelSrc.slice(shieldAt, statusBarAt)
+
+// --- colorized menu-bar icon ------------------------------------------------
+
+check("colorized icon reads the persisted boolean setting",
+  /readonly property bool colorizeIcon: Model\.boolSetting\("colorizeIcon", setting\("colorizeIcon", false\)\)/.test(panelSrc),
+  "expected a false-safe colorizeIcon setting property")
+
+check("colorized icon uses the theme accent only when enabled",
+  /color:\s*root\.colorizeIcon \? Color\.accent : \(bar \? bar\.barForeground : Color\.foreground\)/.test(shield),
+  "expected the primary shield to select Color.accent or its existing foreground")
+
+check("colorized icon leaves status badges independent",
+  shield.includes("color: bar ? bar.urgent : Color.urgent")
+    && shield.includes("color: bar ? bar.barForeground : Color.foreground"),
+  "expected urgent and locked badge colors to remain independently bound")
+
+check("custom shield uses Omarchy's optical glyph renderer",
+  shield.includes("OpticalGlyph")
+    && shield.includes("fontSize: Style.bar.iconFont"),
+  "expected the primary shield to share BarIconButton's OpticalGlyph path")
+
 check("the settings screen has a wrapper outside the scroll area", screenAt >= 0,
   "expected a settingsScreen Column")
 

--- a/tests/setup-settings.test.js
+++ b/tests/setup-settings.test.js
@@ -198,6 +198,21 @@ for (const [label, raw] of [["empty", ""], ["garbage", "???\n=\nbw\n"]]) {
 // assertions read the script rather than an argv list.
 const writeScript = (k, v, t) => Model.settingWriteCommand(k, v, t)[2]
 
+// --- colorized menu-bar icon setting ----------------------------------------
+const colorizeIcon = Model.SETTINGS_SCHEMA.find(e => e.key === "colorizeIcon")
+check("colorized icon setting is declared in General", !!colorizeIcon
+  && colorizeIcon.group === "general"
+  && colorizeIcon.type === "bool",
+  JSON.stringify(colorizeIcon))
+check("colorized icon defaults off", !!colorizeIcon && colorizeIcon.defaultValue === false,
+  JSON.stringify(colorizeIcon))
+check("colorized icon accepts only actual booleans",
+  Model.boolSetting("colorizeIcon", true) === true
+    && Model.boolSetting("colorizeIcon", false) === false
+    && Model.boolSetting("colorizeIcon", "true") === false
+    && Model.boolSetting("colorizeIcon", 1) === false,
+  "malformed colorizeIcon input was accepted")
+
 check("boolean settings accept actual JSON booleans",
   Model.boolSetting("fingerprintUnlock", true) === true
     && Model.boolSetting("fingerprintUnlock", false) === false,
@@ -239,6 +254,15 @@ for (const entry of Model.SETTINGS_SCHEMA) {
   check(`schema key '${entry.key}' exists in manifest.json`,
     manifestKeys.has(entry.key), `manifest has [${[...manifestKeys]}]`)
 }
+const colorizeManifest = manifest.barWidget.schema.find(e => e.key === "colorizeIcon")
+check("manifest colorized icon schema matches the model contract",
+  !!colorizeManifest
+    && colorizeManifest.type === "boolean"
+    && colorizeManifest.label === colorizeIcon.label
+    && colorizeManifest.description === colorizeIcon.description
+    && colorizeManifest.defaultValue === false
+    && manifest.barWidget.defaults.colorizeIcon === false,
+  JSON.stringify({ model: colorizeIcon, manifest: colorizeManifest }))
 
 // --- install command --------------------------------------------------------
 check("no packages yields no command", Model.installPackagesCommand([]) === null, "expected null")


### PR DESCRIPTION
## Summary
- add an opt-in General setting to colorize the Bitwarden shield with the active Omarchy theme accent
- preserve locked, setup, and urgent/error badge colors
- optically center the custom shield glyph so the open-panel indicator aligns with the painted icon
- add regression coverage and user-facing documentation

## Verification
- full JavaScript suite passes
- QML suite: 44 passed
- Qt6 qmllint exits successfully with existing baseline warnings
- omarchy plugin validate passes

Manual runtime verification of the indicator alignment remains pending because omarchy-shell is not running in the current session.