### PR TITLE
fix: center menu-bar panel indicator at fractional scale

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -6518,12 +6518,28 @@ Panel {
       anchors.fill: parent
 
       // Constant Base Shield
-      OpticalGlyph {
-        anchors.fill: parent
+      TextMetrics {
+        id: shieldGlyphMetrics
+        font.family: root.fontFamily
+        font.pixelSize: Style.bar.iconFont
         text: "󰞀"
-        fontFamily: root.fontFamily
-        fontSize: Style.bar.iconFont
+      }
+
+      Text {
+        textFormat: Text.PlainText
+        id: shieldGlyph
+        // Native text is snapped before fractional output scaling. Keep this
+        // glyph in Qt's scene graph so its corrected painted center stays on
+        // the same logical centerline as the bar's panel-open indicator.
+        anchors.centerIn: parent
+        anchors.horizontalCenterOffset: shieldGlyph.implicitWidth / 2
+          - (shieldGlyphMetrics.tightBoundingRect.x
+            + shieldGlyphMetrics.tightBoundingRect.width / 2)
+        text: "󰞀"
+        font.family: root.fontFamily
+        font.pixelSize: Style.bar.iconFont
         color: root.colorizeIcon ? Color.accent : (bar ? bar.barForeground : Color.foreground)
+        renderType: Text.QtRendering
       }
 
       // Mini Install Badge in the same corner while a required tool is absent.

--- a/tests/settings-screen.test.js
+++ b/tests/settings-screen.test.js
@@ -40,10 +40,16 @@ check("colorized icon leaves status badges independent",
     && shield.includes("color: bar ? bar.barForeground : Color.foreground"),
   "expected urgent and locked badge colors to remain independently bound")
 
-check("custom shield uses Omarchy's optical glyph renderer",
-  shield.includes("OpticalGlyph")
-    && shield.includes("fontSize: Style.bar.iconFont"),
-  "expected the primary shield to share BarIconButton's OpticalGlyph path")
+check("panel-open indicator keeps Omarchy's standard width",
+  !panelSrc.includes("openPanelIndicatorWidth"),
+  "expected no plugin-specific width override for the panel-open indicator")
+
+check("custom shield preserves fractional positioning through the scene graph",
+  shield.includes("id: shieldGlyphMetrics")
+    && shield.includes("shieldGlyphMetrics.tightBoundingRect")
+    && shield.includes("anchors.horizontalCenterOffset")
+    && shield.includes("renderType: Text.QtRendering"),
+  "expected a scene-graph-rendered shield with corrected painted side bearings")
 
 check("the settings screen has a wrapper outside the scroll area", screenAt >= 0,
   "expected a settingsScreen Column")


### PR DESCRIPTION
## Summary\n- restore Omarchy's standard panel-open underline width\n- keep the custom shield glyph optically centered at fractional display scales\n- add regression coverage for the standard indicator and scene-graph rendering\n\n## Verification\n- complete JavaScript suite passes\n- QML suite: 44 passed\n- release provenance and settings checks pass\n- omarchy plugin validation passes\n- manually verified on a 1.6x display scale; glyph and underline visual centroids differ by 0.1 physical pixels\n\nThis PR targets the new release/1.8.1 branch, which contains the already-separated colorized-icon feature baseline and version metadata.